### PR TITLE
feat: 2026 driver & constructor content and slug page redesign

### DIFF
--- a/src/content/constructors/2026/alpine.md
+++ b/src/content/constructors/2026/alpine.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 1998
   polePositions: 20
   fastestLaps: 0
-championshipPosition: 10
+championshipPosition: 5
 constructorName: "Alpine"
-constructorPoints: 0
+constructorPoints: 16
 dnf: 0
 description: "Alpine team description"
 engineSupplier: "Renault"

--- a/src/content/constructors/2026/aston-martin.md
+++ b/src/content/constructors/2026/aston-martin.md
@@ -14,7 +14,7 @@ careerStats:
   careerPoints: 843
   polePositions: 1
   fastestLaps: 3
-championshipPosition: 7
+championshipPosition: 11
 constructorName: "Aston Martin"
 constructorPoints: 0
 dnf: 0

--- a/src/content/constructors/2026/audi.md
+++ b/src/content/constructors/2026/audi.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 1078
   polePositions: 1
   fastestLaps: 0
-championshipPosition: 9
+championshipPosition: 8
 constructorName: "Audi"
-constructorPoints: 0
+constructorPoints: 2
 dnf: 0
 description: "Audi team description"
 engineSupplier: "Ferrari"

--- a/src/content/constructors/2026/cadillac.md
+++ b/src/content/constructors/2026/cadillac.md
@@ -14,7 +14,7 @@ constructorName: "Cadillac"
 constructorPoints: 0
 description: "Cadillac joins the Formula 1 grid with a manufacturer-backed effort focused on sustainable powertrain development and a high-downforce chassis package."
 engineSupplier: "Cadillac"
-championshipPosition: 11
+championshipPosition: 10
 season: "2026"
 teamDrivers: ["Sergio Perez", "Valtteri Bottas"]
 teamLogo: ""

--- a/src/content/constructors/2026/ferrari.md
+++ b/src/content/constructors/2026/ferrari.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 10633
   polePositions: 254
   fastestLaps: 180
-championshipPosition: 4
+championshipPosition: 2
 constructorName: "Ferrari"
-constructorPoints: 0
+constructorPoints: 90
 dnf: 0
 description: "Ferrari team description"
 engineSupplier: "Ferrari"

--- a/src/content/constructors/2026/haas.md
+++ b/src/content/constructors/2026/haas.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 369
   polePositions: 1
   fastestLaps: 0
-championshipPosition: 8
+championshipPosition: 4
 constructorName: "Haas"
-constructorPoints: 0
+constructorPoints: 46
 dnf: 0
 description: "Haas team description"
 engineSupplier: "Ferrari"

--- a/src/content/constructors/2026/mclaren.md
+++ b/src/content/constructors/2026/mclaren.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 7663.5
   polePositions: 174
   fastestLaps: 182
-championshipPosition: 1
+championshipPosition: 3
 constructorName: "McLaren"
-constructorPoints: 0
+constructorPoints: 45
 dnf: 0
 description: "McLaren team description"
 engineSupplier: "Mercedes"

--- a/src/content/constructors/2026/mercedes.md
+++ b/src/content/constructors/2026/mercedes.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 8045.5
   polePositions: 136
   fastestLaps: 114
-championshipPosition: 2
+championshipPosition: 1
 constructorName: "Mercedes"
-constructorPoints: 0
+constructorPoints: 135
 dnf: 0
 description: "Mercedes team description"
 engineSupplier: "Mercedes"

--- a/src/content/constructors/2026/racing-bulls.md
+++ b/src/content/constructors/2026/racing-bulls.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 927
   polePositions: 1
   fastestLaps: 0
-championshipPosition: 6
+championshipPosition: 7
 constructorName: "Racing Bulls"
-constructorPoints: 0
+constructorPoints: 14
 dnf: 0
 description: "Racing Bulls team description"
 engineSupplier: "Honda RBPT"

--- a/src/content/constructors/2026/red-bull-racing.md
+++ b/src/content/constructors/2026/red-bull-racing.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 8158
   polePositions: 109
   fastestLaps: 101
-championshipPosition: 3
+championshipPosition: 6
 constructorName: "Red Bull Racing"
-constructorPoints: 0
+constructorPoints: 15
 dnf: 0
 description: "Red Bull Racing team description"
 engineSupplier: "Honda RBPT"

--- a/src/content/constructors/2026/williams.md
+++ b/src/content/constructors/2026/williams.md
@@ -14,9 +14,9 @@ careerStats:
   careerPoints: 3742
   polePositions: 128
   fastestLaps: 132
-championshipPosition: 5
+championshipPosition: 9
 constructorName: "Williams"
-constructorPoints: 0
+constructorPoints: 2
 dnf: 0
 description: "Williams team description"
 engineSupplier: "Mercedes"

--- a/src/content/drivers/2026/alex-albon.md
+++ b/src/content/drivers/2026/alex-albon.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Alex Albon"
 profileImageLargeAlt: "Portrait of Alex Albon"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 8
+championshipPosition: 18
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/arvid-lindblad.md
+++ b/src/content/drivers/2026/arvid-lindblad.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Arvid Lindblad"
 profileImageLargeAlt: "Portrait of Arvid Lindblad"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 24
+driverPoints: 4
+championshipPosition: 11
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/carlos-sainz.md
+++ b/src/content/drivers/2026/carlos-sainz.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Carlos Sainz"
 profileImageLargeAlt: "Portrait of Carlos Sainz"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 9
+driverPoints: 2
+championshipPosition: 14
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/charles-leclerc.md
+++ b/src/content/drivers/2026/charles-leclerc.md
@@ -13,11 +13,11 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Charles Leclerc"
 profileImageLargeAlt: "Portrait of Charles Leclerc"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 5
+driverPoints: 49
+championshipPosition: 3
 championships: 0
 grandPrixWins: 0
-podiums: 5
+podiums: 1
 polePositions: 1
 fastestLaps: 0
 careerStats:

--- a/src/content/drivers/2026/esteban-ocon.md
+++ b/src/content/drivers/2026/esteban-ocon.md
@@ -13,7 +13,7 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Esteban Ocon"
 profileImageLargeAlt: "Portrait of Esteban Ocon"
 driverLogo: ""
-driverPoints: 0
+driverPoints: 1
 championshipPosition: 15
 championships: 0
 grandPrixWins: 0

--- a/src/content/drivers/2026/fernando-alonso.md
+++ b/src/content/drivers/2026/fernando-alonso.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Fernando Alonso"
 profileImageLargeAlt: "Portrait of Fernando Alonso"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 10
+championshipPosition: 21
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/franco-colapinto.md
+++ b/src/content/drivers/2026/franco-colapinto.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Franco Colapinto"
 profileImageLargeAlt: "Portrait of Franco Colapinto"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 20
+driverPoints: 1
+championshipPosition: 16
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/gabriel-bortoleto.md
+++ b/src/content/drivers/2026/gabriel-bortoleto.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Gabriel Bortoleto"
 profileImageLargeAlt: "Portrait of Gabriel Bortoleto"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 18
+driverPoints: 2
+championshipPosition: 13
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/george-russell.md
+++ b/src/content/drivers/2026/george-russell.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of George Russell"
 profileImageLargeAlt: "Portrait of George Russell"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 4
+driverPoints: 63
+championshipPosition: 2
 championships: 0
 grandPrixWins: 1
 podiums: 6

--- a/src/content/drivers/2026/isack-hadjar.md
+++ b/src/content/drivers/2026/isack-hadjar.md
@@ -13,7 +13,7 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Isack Hadjar"
 profileImageLargeAlt: "Portrait of Isack Hadjar"
 driverLogo: ""
-driverPoints: 0
+driverPoints: 4
 championshipPosition: 12
 championships: 0
 grandPrixWins: 0

--- a/src/content/drivers/2026/kimi-antonelli.md
+++ b/src/content/drivers/2026/kimi-antonelli.md
@@ -7,28 +7,28 @@ description: "Kimi Antonelli 2026 Driver Profile"
 season: "2026"
 nationality: "Italian"
 countryCode: "it"
-age: 18
+age: 19
 profileImage: "../../../assets/constructors/mercedes/drivers/antonelli-02.png"
 profileImageLarge: ""
 profileImageAlt: "Portrait of Kimi Antonelli"
 profileImageLargeAlt: "Portrait of Kimi Antonelli"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 7
+driverPoints: 72
+championshipPosition: 1
 championships: 0
-grandPrixWins: 0
-podiums: 1
+grandPrixWins: 2
+podiums: 2
 polePositions: 0
 fastestLaps: 0
 careerStats:
   championships: 0
   careerPoints: 64
-  grandPrixWins: 0
-  polePositions: 0
+  grandPrixWins: 2
+  polePositions: 2
   fastestLaps: 2
-  podiumPositions: 1
+  podiumPositions: 3
 pubDate: "January 2, 2026"
-updatedDate: "January 2, 2026"
+updatedDate: "March 30, 2026"
 heroImage: ""
 ---
 

--- a/src/content/drivers/2026/lance-stroll.md
+++ b/src/content/drivers/2026/lance-stroll.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Lance Stroll"
 profileImageLargeAlt: "Portrait of Lance Stroll"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 16
+championshipPosition: 22
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/lando-norris.md
+++ b/src/content/drivers/2026/lando-norris.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Lando Norris"
 profileImageLargeAlt: "Portrait of Lando Norris"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 1
+driverPoints: 25
+championshipPosition: 5
 championships: 0
 grandPrixWins: 6
 podiums: 16

--- a/src/content/drivers/2026/lewis-hamilton.md
+++ b/src/content/drivers/2026/lewis-hamilton.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Lewis Hamilton"
 profileImageLargeAlt: "Portrait of Lewis Hamilton"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 6
+driverPoints: 41
+championshipPosition: 4
 championships: 7
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/liam-lawson.md
+++ b/src/content/drivers/2026/liam-lawson.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Liam Lawson"
 profileImageLargeAlt: "Portrait of Liam Lawson"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 14
+driverPoints: 10
+championshipPosition: 10
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/max-verstappen.md
+++ b/src/content/drivers/2026/max-verstappen.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Max Verstappen"
 profileImageLargeAlt: "Portrait of Max Verstappen"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 2
+driverPoints: 12
+championshipPosition: 9
 championships: 4
 grandPrixWins: 5
 podiums: 11

--- a/src/content/drivers/2026/nico-hulkenberg.md
+++ b/src/content/drivers/2026/nico-hulkenberg.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Nico Hulkenberg"
 profileImageLargeAlt: "Portrait of Nico Hulkenberg"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 11
+championshipPosition: 17
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/oliver-bearman.md
+++ b/src/content/drivers/2026/oliver-bearman.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Oliver Bearman"
 profileImageLargeAlt: "Portrait of Oliver Bearman"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 13
+driverPoints: 17
+championshipPosition: 7
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/oscar-piastri.md
+++ b/src/content/drivers/2026/oscar-piastri.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Oscar Piastri"
 profileImageLargeAlt: "Portrait of Oscar Piastri"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 3
+driverPoints: 21
+championshipPosition: 6
 championships: 0
 grandPrixWins: 7
 podiums: 14

--- a/src/content/drivers/2026/pierre-gasly.md
+++ b/src/content/drivers/2026/pierre-gasly.md
@@ -13,8 +13,8 @@ profileImageLarge: ""
 profileImageAlt: "Portrait of Pierre Gasly"
 profileImageLargeAlt: "Portrait of Pierre Gasly"
 driverLogo: ""
-driverPoints: 0
-championshipPosition: 17
+driverPoints: 15
+championshipPosition: 8
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/sergio-perez.md
+++ b/src/content/drivers/2026/sergio-perez.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Sergio Perez"
 profileImageLargeAlt: "Portrait of Sergio Perez"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 22
+championshipPosition: 20
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/content/drivers/2026/valtteri-bottas.md
+++ b/src/content/drivers/2026/valtteri-bottas.md
@@ -14,7 +14,7 @@ profileImageAlt: "Portrait of Valtteri Bottas"
 profileImageLargeAlt: "Portrait of Valtteri Bottas"
 driverLogo: ""
 driverPoints: 0
-championshipPosition: 21
+championshipPosition: 19
 championships: 0
 grandPrixWins: 0
 podiums: 0

--- a/src/pages/seasons/2026/constructors/[slug].astro
+++ b/src/pages/seasons/2026/constructors/[slug].astro
@@ -4,7 +4,6 @@ import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
 import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
-import StatCard from "../../../../components/StatCard.astro";
 import DriverCard from "../../../../components/DriverCard.astro";
 import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
@@ -45,6 +44,27 @@ drivers.forEach((driver) => {
 });
 // team background image (optional)
 const teamBg = teamBgMap[team.data.constructorName] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[team.data.constructorName] || "rgb(244 63 94)";
+const teamCode = team.data.constructorName
+  .split(" ")
+  .map((word) => word[0])
+  .join("")
+  .slice(0, 3)
+  .toUpperCase();
 
 // Hero stats grid items
 const heroStats = [
@@ -110,47 +130,64 @@ const lifetimeStats = [
         ]}
       />
       <!-- Team Profile Header -->
-      <section
-        class="container mb-8 mt-12 rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-950"
-      >
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-          <!-- Left: Car Image -->
-          <div
-            class="flex flex-1 overflow-hidden rounded-2xl"
-            style={teamBg
-              ? `background-image: url('${teamBg.src}'); background-size: cover;`
-              : ""}
-          >
-            <div class="flex flex-1 p-6">
-              <Image
-                src={team.data.carImageLarge || team.data.carImage}
-                alt={team.data.carImageLargeAlt || team.data.carImageAlt}
-                width={600}
-                height={600}
-                class="h-full w-full object-contain"
-                loading="eager"
-              />
+      <section class="container mb-8 mt-12">
+        <div
+          class="team-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Team Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {teamCode}
+              </p>
+              <div class="flex flex-1 p-6 pt-12">
+                <Image
+                  src={team.data.carImageLarge || team.data.carImage}
+                  alt={team.data.carImageLargeAlt || team.data.carImageAlt}
+                  width={600}
+                  height={600}
+                  class="h-full w-full object-contain"
+                  loading="eager"
+                />
+              </div>
             </div>
-          </div>
-          <!-- Right: Constructor Info & Stats -->
-          <div class="space-y-4">
-            <h1 class="font-bold text-zinc-900 dark:text-zinc-100">
-              {team.data.constructorName}
-            </h1>
-            <!-- Stats Grid -->
-            <div class="grid gap-4 sm:grid-cols-2">
-              {
-                heroStats.map((stat) => (
-                  <div class="rounded-xl bg-zinc-200/50 p-4 text-center dark:bg-zinc-800">
-                    <div class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                      {stat.value}
+
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2026 Constructor Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
+                {team.data.constructorName}
+              </h1>
+             
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
                     </div>
-                    <div class="text-base text-zinc-800 dark:text-zinc-400">
-                      {stat.label}
-                    </div>
-                  </div>
-                ))
-              }
+                  ))
+                }
+              </div>
             </div>
           </div>
         </div>
@@ -186,35 +223,60 @@ const lifetimeStats = [
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Team Statistics
           </h2>
-          <div class="mx-auto grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
             {/* Season Statistics Column */}
-            <div class="rounded-xl p-6">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                2026 Season
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  seasonStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2026 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
             {/* Lifetime Statistics Column */}
-            <div class="rounded-xl bg-zinc-200/50 p-6 dark:bg-zinc-700/70">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                Lifetime
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  lifetimeStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
           </div>
@@ -255,5 +317,56 @@ const lifetimeStats = [
       />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .team-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/seasons/2026/drivers/[slug].astro
+++ b/src/pages/seasons/2026/drivers/[slug].astro
@@ -3,7 +3,6 @@ import BaseHead from "../../../../components/BaseHead.astro";
 import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
-import StatCard from "../../../../components/StatCard.astro";
 import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
 import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
@@ -32,6 +31,22 @@ import { teamBgMap } from "../../../../utils/teamBgMap";
 const { Content } = await render(driver);
 // team background for driver's team
 const teamBg = teamBgMap[driver.data.driverTeam] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[driver.data.driverTeam] || "rgb(244 63 94)";
+const driverCode = `${driver.data.driverFirstName?.[0] ?? ""}${driver.data.driverLastName?.[0] ?? ""}`.toUpperCase();
 
 // Hero stats grid items
 const heroStats = [
@@ -88,48 +103,62 @@ const lifetimeStats = [
       />
 
       <!-- driver slug hero -->
-      <section
-        class="mb-8 mt-12 rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-950"
-      >
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-          <!-- Left: Driver Image with team background -->
-          <div
-            class="flex flex-1 items-end justify-end overflow-hidden rounded-2xl"
-            style={teamBg
-              ? `background-image: url('${teamBg.src}'); background-size: cover; background-position: center;`
-              : ""}
-          >
-            <Image
-              src={driver.data.profileImageLarge || driver.data.profileImage}
-              alt={driver.data.profileImageLargeAlt ||
-                driver.data.profileImageAlt}
-              width={400}
-              height={400}
-              class="object-contain object-bottom"
-              loading="eager"
-            />
-          </div>
-          <!-- Right: Driver Info & Stats -->
-          <div>
-            <h1 class="mb-2 font-bold text-zinc-900 dark:text-zinc-100">
-              {driver.data.driverFirstName}
-              {driver.data.driverLastName}
-            </h1>
+      <section class="container mx-auto mb-8 mt-12">
+        <div
+          class="driver-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 items-end justify-end overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Driver Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {driverCode}
+              </p>
+              <Image
+                src={driver.data.profileImageLarge || driver.data.profileImage}
+                alt={driver.data.profileImageLargeAlt ||
+                  driver.data.profileImageAlt}
+                width={400}
+                height={400}
+                class="relative z-10 object-contain object-bottom"
+                loading="eager"
+              />
+            </div>
 
-            <!-- Stats Grid -->
-            <div class="grid grid-cols-2 gap-4">
-              {
-                heroStats.map((stat) => (
-                  <div class="rounded-xl bg-zinc-200/50 p-4 text-center dark:bg-zinc-800">
-                    <div class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                      {stat.value}
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2026 Driver Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
+                {driver.data.driverFirstName} {driver.data.driverLastName}
+              </h1>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
                     </div>
-                    <div class="text-base text-zinc-800 dark:text-zinc-400">
-                      {stat.label}
-                    </div>
-                  </div>
-                ))
-              }
+                  ))
+                }
+              </div>
             </div>
           </div>
         </div>
@@ -141,35 +170,60 @@ const lifetimeStats = [
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Driver Statistics
           </h2>
-          <div class="mx-auto grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
             {/* Season Statistics Column */}
-            <div class="rounded-xl p-6">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                2026 Season
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  seasonStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2026 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
             {/* Lifetime Statistics Column */}
-            <div class="rounded-xl bg-zinc-200/50 p-6 dark:bg-zinc-700/70">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                Lifetime
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  lifetimeStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
           </div>
@@ -188,7 +242,7 @@ const lifetimeStats = [
       </section>
 
       {/* Last Updated Section */}
-      <section class="py-8">
+      <section class="container mx-auto py-8">
         <p class="text-zinc-600 dark:text-zinc-400">
           {
             driver.data.updatedDate && (
@@ -210,5 +264,56 @@ const lifetimeStats = [
       />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .driver-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>


### PR DESCRIPTION
**Summary**
This PR updates the 2026 season driver and constructor experience by:

- Refreshing 2026 driver content entries
- Refreshing 2026 constructor content entries
- Redesigning the 2026 driver slug page layout
- Redesigning the 2026 constructor slug page layout
- The page updates align the 2026 profile pages with the newer visual direction and improved information hierarchy.

**What Changed**

- Updated 2026 driver markdown content for current roster/details
- Updated 2026 constructor markdown content for current teams/details
- Improved 2026 driver profile page structure and presentation
- Improved 2026 constructor profile page structure and presentation

**Scope**
Included:

- 2026 driver content files
- 2026 constructor content files
- 2026 driver slug page
- 2026 constructor slug page

Not included:

- Results section work
- Cross-season backports for 2024/2025
- Global design/system-wide refactors outside the above scope

**Validation**

- Content compiles successfully with current schema
- 2026 driver and constructor pages render correctly
- No breaking route changes for existing 2026 profile URLs