### PR TITLE
feat: add results hub and dynamic race session pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,7 +20,7 @@ const currentSeason = "2026";
 ---
 
 <header
-  class="sticky top-0 z-50 bg-white/95 py-2 shadow-sm backdrop-blur-sm dark:bg-zinc-800/95"
+  class="sticky top-0 z-50 border-t-[3px] border-rose-600 bg-white/95 py-2 shadow-sm backdrop-blur-sm dark:bg-zinc-800/95"
 >
   <nav class="container mx-auto px-4" aria-label="Main navigation">
     <div class="flex h-16 items-center justify-between">
@@ -50,7 +50,7 @@ const currentSeason = "2026";
           href="/"
           class:list={[
             "transition-colors duration-200 dark:text-zinc-200",
-            isActive("/") && "text-blue-600 dark:text-blue-400",
+            isActive("/") && "text-rose-600 dark:text-rose-400",
           ]}
         >
           Home
@@ -60,10 +60,20 @@ const currentSeason = "2026";
           href="/blog"
           class:list={[
             "transition-colors duration-200 dark:text-zinc-200",
-            isActive("/blog") && "text-blue-600 dark:text-blue-400",
+            isActive("/blog") && "text-rose-600 dark:text-rose-400",
           ]}
         >
           Blog
+        </HeaderLink>
+
+        <HeaderLink
+          href="/results"
+          class:list={[
+            "transition-colors duration-200 dark:text-zinc-200",
+            isActive("/results") && "text-rose-600 dark:text-rose-400",
+          ]}
+        >
+          Results
         </HeaderLink>
 
         <!-- Seasons Mega Menu -->
@@ -71,7 +81,7 @@ const currentSeason = "2026";
           <button
             class:list={[
               "nav-dropdown-trigger inline-flex items-center gap-1 py-2 font-medium transition-colors duration-200 dark:text-zinc-200",
-              isActive("/seasons") && "text-blue-600 dark:text-blue-400",
+              isActive("/seasons") && "text-rose-600 dark:text-rose-400",
             ]}
             aria-expanded="false"
             aria-haspopup="true"
@@ -91,20 +101,20 @@ const currentSeason = "2026";
             >
               <!-- Current Season Highlight -->
               <div
-                class="bg-linear-to-r border-b border-zinc-100 from-blue-50 to-zinc-50 p-4 dark:border-zinc-700 dark:from-blue-900/20 dark:to-zinc-800"
+                class="bg-linear-to-r border-b border-zinc-100 from-rose-50 to-zinc-50 p-4 dark:border-zinc-700 dark:from-rose-900/20 dark:to-zinc-800"
               >
                 <a
                   href={`/seasons/${currentSeason}`}
                   class="group/current flex items-center gap-3"
                 >
                   <div
-                    class="flex size-10 items-center justify-center rounded-lg bg-blue-600 text-white"
+                    class="flex size-10 items-center justify-center rounded-lg bg-rose-600 text-white"
                   >
                     <Icon name="mdi:flag-checkered" size={20} />
                   </div>
                   <div>
                     <div
-                      class="font-semibold text-zinc-900 group-hover/current:text-blue-600 dark:text-zinc-100 dark:group-hover/current:text-blue-400"
+                      class="font-semibold text-zinc-900 group-hover/current:text-rose-600 dark:text-zinc-100 dark:group-hover/current:text-rose-400"
                     >
                       {currentSeason} Season
                       <span
@@ -141,10 +151,21 @@ const currentSeason = "2026";
                 </a>
                 <a
                   href={`/seasons/${currentSeason}/races`}
-                  class="col-span-2 flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                  class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
                 >
                   <Icon name="mdi:calendar" size={18} class="text-zinc-500" />
                   Race Calendar
+                </a>
+                <a
+                  href="/results"
+                  class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-700"
+                >
+                  <Icon
+                    name="mdi:trophy-outline"
+                    size={18}
+                    class="text-zinc-500"
+                  />
+                  Results
                 </a>
               </div>
 
@@ -173,7 +194,7 @@ const currentSeason = "2026";
               <div class="border-t border-zinc-100 p-2 dark:border-zinc-700">
                 <a
                   href="/seasons"
-                  class="flex items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                  class="flex items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-900/20"
                 >
                   View all seasons
                   <Icon name="mdi:arrow-right" size={16} />
@@ -188,7 +209,7 @@ const currentSeason = "2026";
           <button
             class:list={[
               "nav-dropdown-trigger inline-flex items-center gap-1 py-2 font-medium transition-colors duration-200 dark:text-zinc-200",
-              isActive("/learn") && "text-blue-600 dark:text-blue-400",
+              isActive("/learn") && "text-rose-600 dark:text-rose-400",
             ]}
             aria-expanded="false"
             aria-haspopup="true"
@@ -267,7 +288,7 @@ const currentSeason = "2026";
           <button
             class:list={[
               "nav-dropdown-trigger inline-flex items-center gap-1 py-2 font-medium transition-colors duration-200 dark:text-zinc-200",
-              isActive("/about") && "text-blue-600 dark:text-blue-400",
+              isActive("/about") && "text-rose-600 dark:text-rose-400",
             ]}
             aria-expanded="false"
             aria-haspopup="true"
@@ -343,7 +364,7 @@ const currentSeason = "2026";
       <div class="md:hidden">
         <button
           type="button"
-          class="mobile-menu-button inline-flex items-center justify-center rounded-md p-2 text-zinc-700 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          class="mobile-menu-button inline-flex items-center justify-center rounded-md p-2 text-zinc-700 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-rose-500 dark:text-zinc-300 dark:hover:bg-zinc-700"
           aria-expanded="false"
           aria-controls="mobile-menu"
           aria-label="Toggle navigation menu"
@@ -378,7 +399,7 @@ const currentSeason = "2026";
           class:list={[
             "block rounded-lg px-3 py-2.5 text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
             isActive("/")
-              ? "bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
+              ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
               : "text-zinc-700 hover:bg-zinc-50",
           ]}>Home</a
         >
@@ -389,9 +410,20 @@ const currentSeason = "2026";
           class:list={[
             "block rounded-lg px-3 py-2.5 text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
             isActive("/blog")
-              ? "bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
+              ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
               : "text-zinc-700 hover:bg-zinc-50",
           ]}>Blog</a
+        >
+
+        <!-- Results -->
+        <a
+          href="/results"
+          class:list={[
+            "block rounded-lg px-3 py-2.5 text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
+            isActive("/results")
+              ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
+              : "text-zinc-700 hover:bg-zinc-50",
+          ]}>Results</a
         >
 
         <!-- Mobile Seasons Section -->
@@ -400,7 +432,7 @@ const currentSeason = "2026";
             class:list={[
               "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
               isActive("/seasons")
-                ? "bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
+                ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
                 : "text-zinc-700 hover:bg-zinc-50",
             ]}
             aria-expanded="false"
@@ -419,7 +451,7 @@ const currentSeason = "2026";
               <!-- Current Season Highlight -->
               <a
                 href={`/seasons/${currentSeason}`}
-                class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                class="flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-900/20"
               >
                 <Icon name="mdi:flag-checkered" size={16} />
                 {currentSeason} Season
@@ -429,7 +461,7 @@ const currentSeason = "2026";
                 >
               </a>
               <!-- Quick Links -->
-              <div class="grid grid-cols-3 gap-1 py-1">
+              <div class="grid grid-cols-2 gap-1 py-1">
                 <a
                   href={`/seasons/${currentSeason}/drivers`}
                   class="rounded-lg px-2 py-1.5 text-center text-xs text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
@@ -445,6 +477,11 @@ const currentSeason = "2026";
                   class="rounded-lg px-2 py-1.5 text-center text-xs text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
                   >Races</a
                 >
+                <a
+                  href="/results"
+                  class="rounded-lg px-2 py-1.5 text-center text-xs text-zinc-600 transition-colors hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                  >Results</a
+                >
               </div>
               <!-- Past Seasons -->
               <a
@@ -459,7 +496,7 @@ const currentSeason = "2026";
               >
               <a
                 href="/seasons"
-                class="block rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/20"
+                class="block rounded-lg px-3 py-2 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-900/20"
                 >View all seasons →</a
               >
             </div>
@@ -472,7 +509,7 @@ const currentSeason = "2026";
             class:list={[
               "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
               isActive("/learn")
-                ? "bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
+                ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
                 : "text-zinc-700 hover:bg-zinc-50",
             ]}
             aria-expanded="false"
@@ -513,7 +550,7 @@ const currentSeason = "2026";
             class:list={[
               "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left text-base font-medium transition-colors dark:text-zinc-200 dark:hover:bg-zinc-700",
               isActive("/about")
-                ? "bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
+                ? "bg-rose-50 text-rose-600 dark:bg-rose-900/20 dark:text-rose-400"
                 : "text-zinc-700 hover:bg-zinc-50",
             ]}
             aria-expanded="false"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -126,12 +126,106 @@ const races = defineCollection({
   // Type-check frontmatter using a schema
   schema: ({ image }) =>
     z.object({
+      raceWeekendDateRange: z.string().optional(),
+      raceResults: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      practice1Results: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      practice2Results: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      practice3Results: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      qualifyingResults: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      sprintResults: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      fastestLapResults: z
+        .array(
+          z.object({
+            position: z.number(),
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrRetired: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
       time: z.string().optional(),
       fastestLapConstructor: z.string().optional(),
       fastestLapDriver: z.string().optional(),
       fastestLapTime: z.string().optional(),
       heroImage: image().optional(),
+      laps: z.number().default(0).optional(),
       pubDate: z.coerce.date(),
+      hasSprint: z.boolean().default(false).optional(),
       raceCompleted: z.boolean().default(false),
       raceDate: z.coerce.date(),
       raceName: z.string(),

--- a/src/content/races/2026/australian-gp.md
+++ b/src/content/races/2026/australian-gp.md
@@ -18,8 +18,54 @@ winningConstructor: "Mercedes"
 fastestLapDriver: "Max Verstappen"
 fastestLapConstructor: "Red Bull Racing"
 fastestLapTime: "1:22.091"
+raceWeekendDateRange: "06 - 08 MAR 2026"
 raceNumber: 1
+laps: 58
+time: "1:23:06.801"
 raceCompleted: true
+raceResults:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 58
+    timeOrRetired: "1:23:06.801"
+    points: 25
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 58
+    timeOrRetired: "+2.974s"
+    points: 18
+  - position: 3
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 58
+    timeOrRetired: "+15.519s"
+    points: 15
+  - position: 4
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 58
+    timeOrRetired: "+16.144s"
+    points: 12
+  - position: 5
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 58
+    timeOrRetired: "+51.741s"
+    points: 10
+  - position: 6
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 58
+    timeOrRetired: "+54.617s"
+    points: 8
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/01australia/aus01.jpg"
 ---

--- a/src/content/races/2026/china-gp.md
+++ b/src/content/races/2026/china-gp.md
@@ -19,6 +19,9 @@ fastestLapDriver: "Kimi Antonelli"
 fastestLapConstructor: "Mercedes"
 fastestLapTime: "1:35.275"
 raceNumber: 2
+laps: 56
+time: "1:33:15.607"
+hasSprint: true
 raceCompleted: true
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/02china/cn01.jpg"

--- a/src/content/races/2026/japan-gp.md
+++ b/src/content/races/2026/japan-gp.md
@@ -3,8 +3,8 @@ raceName: "Formula 1 Aramco Japanese Grand Prix 2026"
 trackName: "Suzuka Circuit"
 trackLocation: "Suzuka"
 trackCountry: "Japan"
-trackImage: "../../../assets/circuits/06miami/mi01.jpg"
-trackImageLarge: "../../../assets/circuits/06miami/mi01.jpg"
+trackImage: "../../../assets/circuits/03japan/jp05.jpg"
+trackImageLarge: "../../../assets/circuits/03japan/jp05.jpg"
 trackImageAlt: "Suzuka Circuit"
 trackImageLargeAlt: "Suzuka Circuit"
 raceDate: "March 29, 2026"
@@ -19,9 +19,11 @@ fastestLapDriver: "Kimi Antonelli"
 fastestLapConstructor: "Mercedes"
 fastestLapTime: "1:32.432"
 raceNumber: 3
+laps: 53
+time: "1:28:03.403"
 raceCompleted: true
 pubDate: "January 02, 2026"
-heroImage: "../../../assets/circuits/06miami/mi01.jpg"
+heroImage: "../../../assets/circuits/03japan/jp05.jpg"
 ---
 
 # Japan Grand Prix 2026

--- a/src/pages/results/[season]/races/[raceSlug].astro
+++ b/src/pages/results/[season]/races/[raceSlug].astro
@@ -1,0 +1,331 @@
+---
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import BaseHead from "../../../../components/BaseHead.astro";
+import Header from "../../../../components/Header.astro";
+import Footer from "../../../../components/Footer.astro";
+import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
+import { Icon } from "astro-icon/components";
+import { SITE_TITLE } from "../../../../consts";
+import { getSlugFromEntry } from "../../../../utils/slugUtils";
+
+const normalizeName = (value: string) => value.trim().toLowerCase();
+
+const SESSION_OPTIONS = [
+  { id: "race", label: "Race Result" },
+  { id: "practice-1", label: "Practice 1" },
+  { id: "practice-2", label: "Practice 2" },
+  { id: "practice-3", label: "Practice 3" },
+  { id: "qualifying", label: "Qualifying" },
+  { id: "sprint", label: "Sprint" },
+  { id: "fastest-laps", label: "Fastest Laps" },
+] as const;
+
+type SessionId = (typeof SESSION_OPTIONS)[number]["id"];
+type RaceEntry = CollectionEntry<"races">;
+type DriverEntry = CollectionEntry<"drivers">;
+type ConstructorEntry = CollectionEntry<"constructors">;
+type ResultRow = NonNullable<RaceEntry["data"]["raceResults"]>[number];
+
+export async function getStaticPaths() {
+  const races = await getCollection(
+    "races",
+    ({ data }: { data: RaceEntry["data"] }) => data.raceWeekend === "Race",
+  );
+
+  return races.map((race: RaceEntry) => ({
+    params: {
+      season: race.data.season,
+      raceSlug: getSlugFromEntry(race),
+    },
+    props: { race },
+  }));
+}
+
+const { race } = Astro.props as { race: RaceEntry };
+const season = race.data.season;
+const raceSlug = getSlugFromEntry(race);
+const basePath = `/results/${season}/races/${raceSlug}`;
+
+const seasonRaces = (await getCollection(
+  "races",
+  ({ data }: { data: RaceEntry["data"] }) =>
+    data.season === season && data.raceWeekend === "Race",
+)).sort((a: RaceEntry, b: RaceEntry) => a.data.raceNumber - b.data.raceNumber);
+
+const seasonDrivers = await getCollection(
+  "drivers",
+  ({ data }: { data: DriverEntry["data"] }) => data.season === season,
+);
+const seasonConstructors = await getCollection(
+  "constructors",
+  ({ data }: { data: ConstructorEntry["data"] }) => data.season === season,
+);
+
+const driverSlugByFullName = new Map(
+  seasonDrivers.map((driver: DriverEntry) => [
+    normalizeName(`${driver.data.driverFirstName} ${driver.data.driverLastName}`),
+    getSlugFromEntry(driver),
+  ]),
+);
+
+const constructorSlugByName = new Map(
+  seasonConstructors.map((team: ConstructorEntry) => [
+    normalizeName(team.data.constructorName),
+    getSlugFromEntry(team),
+  ]),
+);
+
+const activeSession: SessionId = "race";
+const visibleSessions = SESSION_OPTIONS.filter(
+  (s) => s.id !== "sprint" || race.data.hasSprint,
+);
+
+const sessionRowsMap: Record<SessionId, ResultRow[]> = {
+  race: race.data.raceResults ?? [],
+  "practice-1": race.data.practice1Results ?? [],
+  "practice-2": race.data.practice2Results ?? [],
+  "practice-3": race.data.practice3Results ?? [],
+  qualifying: race.data.qualifyingResults ?? [],
+  sprint: race.data.sprintResults ?? [],
+  "fastest-laps": race.data.fastestLapResults ?? [],
+};
+
+const activeRows = sessionRowsMap[activeSession];
+const activeLabel =
+  SESSION_OPTIONS.find((option) => option.id === activeSession)?.label ??
+  "Race Result";
+
+const dateLabel = race.data.raceWeekendDateRange
+  ? race.data.raceWeekendDateRange
+  : new Date(race.data.raceDate).toLocaleDateString("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+
+const countryFlagMap: Record<string, string> = {
+  Australia: "au",
+  China: "cn",
+  Japan: "jp",
+  Bahrain: "bh",
+  "Saudi Arabia": "sa",
+  Miami: "us",
+  "Emilia Romagna": "it",
+  Monaco: "mc",
+  Spain: "es",
+  Canada: "ca",
+  Austria: "at",
+  "Great Britain": "gb",
+  Hungary: "hu",
+  Belgium: "be",
+  Netherlands: "nl",
+  Italy: "it",
+  Azerbaijan: "az",
+  Singapore: "sg",
+  "United States": "us",
+  Mexico: "mx",
+  Brazil: "br",
+  "Las Vegas": "us",
+  Qatar: "qa",
+  "Abu Dhabi": "ae",
+};
+
+const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
+---
+
+<!doctype html>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`${race.data.raceName} ${activeLabel} | ${SITE_TITLE}`}
+      description={`${activeLabel} for ${race.data.raceName} in the ${season} Formula 1 season`}
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Home", href: "/" },
+          { text: "Results", href: "/results" },
+          { text: season, href: "/results" },
+          { text: race.data.trackCountry },
+        ]}
+      />
+
+      <section class="container mx-auto mb-12 mt-8 px-4">
+        <div class="overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 px-5 py-6 text-zinc-100 sm:px-8 sm:py-7">
+          <div class="mb-6 flex flex-wrap items-center gap-3">
+            <div class="w-full sm:w-auto">
+              <label for="race-select" class="sr-only">Select race</label>
+              <div class="relative">
+              <select
+                id="race-select"
+                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+              >
+                {
+                  seasonRaces.map((raceOption: RaceEntry) => {
+                    const optionSlug = getSlugFromEntry(raceOption);
+                    return (
+                      <option
+                        value={`/results/${season}/races/${optionSlug}`}
+                        selected={optionSlug === raceSlug}
+                      >
+                        {raceOption.data.trackCountry}
+                      </option>
+                    );
+                  })
+                }
+              </select>
+              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                <Icon name="mdi:chevron-down" size={18} />
+              </span>
+              </div>
+            </div>
+
+            <div class="w-full sm:w-auto">
+              <label for="session-select" class="sr-only">Select session</label>
+              <div class="relative">
+              <select
+                id="session-select"
+                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+              >
+                {
+                  visibleSessions.map((option) => (
+                    <option
+                      value={
+                        option.id === "race"
+                          ? basePath
+                          : `${basePath}/${option.id}`
+                      }
+                      selected={option.id === activeSession}
+                    >
+                      {option.label}
+                    </option>
+                  ))
+                }
+              </select>
+              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                <Icon name="mdi:chevron-down" size={18} />
+              </span>
+              </div>
+            </div>
+
+            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-600 p-2 sm:flex">
+              <span class={`fi fi-${flagCode} rounded-sm`} />
+            </div>
+          </div>
+
+          <h1 class="max-w-4xl text-3xl font-black uppercase leading-tight tracking-tight sm:text-5xl">
+            {race.data.raceName} - {activeLabel}
+          </h1>
+
+          <p class="mt-5 text-sm font-bold uppercase text-zinc-300 sm:text-base">
+            {dateLabel}
+          </p>
+          <p class="text-zinc-300">
+            {race.data.trackName}, {race.data.trackLocation}
+          </p>
+
+          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-800 bg-black">
+            <table class="w-full text-sm">
+              <thead class="border-b border-zinc-800">
+                <tr>
+                  {[
+                    "Pos.",
+                    "No.",
+                    "Driver",
+                    "Team",
+                    "Laps",
+                    "Time / Retired",
+                    "Pts.",
+                  ].map((heading) => (
+                    <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-300">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  activeRows.length > 0 ? (
+                    activeRows.map((row: ResultRow) => {
+                      const driverSlug = driverSlugByFullName.get(
+                        normalizeName(row.driver),
+                      );
+                      const teamSlug = constructorSlugByName.get(
+                        normalizeName(row.team),
+                      );
+                      return (
+                        <tr class="border-b border-zinc-900 last:border-b-0">
+                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                            {row.position}
+                          </td>
+                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                            {row.carNumber ?? "-"}
+                          </td>
+                          <td class="px-4 py-4 font-semibold text-zinc-100">
+                            {driverSlug ? (
+                              <a
+                                href={`/seasons/${season}/drivers/${driverSlug}`}
+                                class="hover:text-rose-400"
+                              >
+                                {row.driver}
+                              </a>
+                            ) : (
+                              row.driver
+                            )}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">
+                            {teamSlug ? (
+                              <a
+                                href={`/seasons/${season}/constructors/${teamSlug}`}
+                                class="hover:text-rose-400"
+                              >
+                                {row.team}
+                              </a>
+                            ) : (
+                              row.team
+                            )}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">{row.laps ?? "-"}</td>
+                          <td class="px-4 py-4 font-mono text-zinc-100">
+                            {row.timeOrRetired ?? "-"}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">{row.points ?? "-"}</td>
+                        </tr>
+                      );
+                    })
+                  ) : (
+                    <tr>
+                      <td colspan={7} class="px-4 py-10 text-center text-zinc-400">
+                        {activeLabel} data is not available yet for this Grand Prix.
+                      </td>
+                    </tr>
+                  )
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+    <Footer />
+
+    <script>
+      const raceSelect = document.getElementById("race-select") as HTMLSelectElement;
+      const sessionSelect = document.getElementById(
+        "session-select",
+      ) as HTMLSelectElement;
+
+      raceSelect?.addEventListener("change", () => {
+        window.location.href = raceSelect.value;
+      });
+
+      sessionSelect?.addEventListener("change", () => {
+        window.location.href = sessionSelect.value;
+      });
+    </script>
+  </body>
+</html>

--- a/src/pages/results/[season]/races/[raceSlug]/[session].astro
+++ b/src/pages/results/[season]/races/[raceSlug]/[session].astro
@@ -1,0 +1,353 @@
+---
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import BaseHead from "../../../../../components/BaseHead.astro";
+import Header from "../../../../../components/Header.astro";
+import Footer from "../../../../../components/Footer.astro";
+import Breadcrumbs from "../../../../../components/Breadcrumbs.astro";
+import { Icon } from "astro-icon/components";
+import { SITE_TITLE } from "../../../../../consts";
+import { getSlugFromEntry } from "../../../../../utils/slugUtils";
+
+const normalizeName = (value: string) => value.trim().toLowerCase();
+
+const SESSION_OPTIONS = [
+  { id: "race", label: "Race Result" },
+  { id: "practice-1", label: "Practice 1" },
+  { id: "practice-2", label: "Practice 2" },
+  { id: "practice-3", label: "Practice 3" },
+  { id: "qualifying", label: "Qualifying" },
+  { id: "sprint", label: "Sprint" },
+  { id: "fastest-laps", label: "Fastest Laps" },
+] as const;
+
+type SessionId = (typeof SESSION_OPTIONS)[number]["id"];
+type RaceEntry = CollectionEntry<"races">;
+type DriverEntry = CollectionEntry<"drivers">;
+type ConstructorEntry = CollectionEntry<"constructors">;
+type ResultRow = NonNullable<RaceEntry["data"]["raceResults"]>[number];
+
+export async function getStaticPaths() {
+  const SESSION_IDS = [
+    "race",
+    "practice-1",
+    "practice-2",
+    "practice-3",
+    "qualifying",
+    "sprint",
+    "fastest-laps",
+  ] as const;
+
+  const races = await getCollection(
+    "races",
+    ({ data }: { data: RaceEntry["data"] }) => data.raceWeekend === "Race",
+  );
+
+  return races.flatMap((race: RaceEntry) =>
+    SESSION_IDS.map((session) => ({
+      params: {
+        season: race.data.season,
+        raceSlug: getSlugFromEntry(race),
+        session,
+      },
+      props: { race },
+    })),
+  );
+}
+
+const { race } = Astro.props as { race: RaceEntry };
+const { session: sessionParam } = Astro.params;
+const season = race.data.season;
+const raceSlug = getSlugFromEntry(race);
+const basePath = `/results/${season}/races/${raceSlug}`;
+
+const activeSession: SessionId = SESSION_OPTIONS.some(
+  (s) => s.id === sessionParam,
+)
+  ? (sessionParam as SessionId)
+  : "race";
+
+const seasonRaces = (await getCollection(
+  "races",
+  ({ data }: { data: RaceEntry["data"] }) =>
+    data.season === season && data.raceWeekend === "Race",
+)).sort((a: RaceEntry, b: RaceEntry) => a.data.raceNumber - b.data.raceNumber);
+
+const seasonDrivers = await getCollection(
+  "drivers",
+  ({ data }: { data: DriverEntry["data"] }) => data.season === season,
+);
+const seasonConstructors = await getCollection(
+  "constructors",
+  ({ data }: { data: ConstructorEntry["data"] }) => data.season === season,
+);
+
+const driverSlugByFullName = new Map(
+  seasonDrivers.map((driver: DriverEntry) => [
+    normalizeName(`${driver.data.driverFirstName} ${driver.data.driverLastName}`),
+    getSlugFromEntry(driver),
+  ]),
+);
+
+const constructorSlugByName = new Map(
+  seasonConstructors.map((team: ConstructorEntry) => [
+    normalizeName(team.data.constructorName),
+    getSlugFromEntry(team),
+  ]),
+);
+
+const sessionRowsMap: Record<SessionId, ResultRow[]> = {
+  race: race.data.raceResults ?? [],
+  "practice-1": race.data.practice1Results ?? [],
+  "practice-2": race.data.practice2Results ?? [],
+  "practice-3": race.data.practice3Results ?? [],
+  qualifying: race.data.qualifyingResults ?? [],
+  sprint: race.data.sprintResults ?? [],
+  "fastest-laps": race.data.fastestLapResults ?? [],
+};
+
+const activeRows = sessionRowsMap[activeSession];
+const visibleSessions = SESSION_OPTIONS.filter(
+  (s) => s.id !== "sprint" || race.data.hasSprint,
+);
+const activeLabel =
+  SESSION_OPTIONS.find((option) => option.id === activeSession)?.label ??
+  "Race Result";
+
+const dateLabel = race.data.raceWeekendDateRange
+  ? race.data.raceWeekendDateRange
+  : new Date(race.data.raceDate).toLocaleDateString("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+
+const countryFlagMap: Record<string, string> = {
+  Australia: "au",
+  China: "cn",
+  Japan: "jp",
+  Bahrain: "bh",
+  "Saudi Arabia": "sa",
+  Miami: "us",
+  "Emilia Romagna": "it",
+  Monaco: "mc",
+  Spain: "es",
+  Canada: "ca",
+  Austria: "at",
+  "Great Britain": "gb",
+  Hungary: "hu",
+  Belgium: "be",
+  Netherlands: "nl",
+  Italy: "it",
+  Azerbaijan: "az",
+  Singapore: "sg",
+  "United States": "us",
+  Mexico: "mx",
+  Brazil: "br",
+  "Las Vegas": "us",
+  Qatar: "qa",
+  "Abu Dhabi": "ae",
+};
+
+const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
+---
+
+<!doctype html>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`${race.data.raceName} ${activeLabel} | ${SITE_TITLE}`}
+      description={`${activeLabel} for ${race.data.raceName} in the ${season} Formula 1 season`}
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Home", href: "/" },
+          { text: "Results", href: "/results" },
+          { text: season, href: "/results" },
+          { text: race.data.trackCountry },
+        ]}
+      />
+
+      <section class="container mx-auto mb-12 mt-8 px-4">
+        <div class="overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 px-5 py-6 text-zinc-100 sm:px-8 sm:py-7">
+          <div class="mb-6 flex flex-wrap items-center gap-3">
+            <div class="w-full sm:w-auto">
+              <label for="race-select" class="sr-only">Select race</label>
+              <div class="relative">
+                <select
+                  id="race-select"
+                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                >
+                  {
+                    seasonRaces.map((raceOption: RaceEntry) => {
+                      const optionSlug = getSlugFromEntry(raceOption);
+                      return (
+                        <option
+                          value={
+                            activeSession === "race"
+                              ? `/results/${season}/races/${optionSlug}`
+                              : `/results/${season}/races/${optionSlug}/${activeSession}`
+                          }
+                          selected={optionSlug === raceSlug}
+                        >
+                          {raceOption.data.trackCountry}
+                        </option>
+                      );
+                    })
+                  }
+                </select>
+                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                  <Icon name="mdi:chevron-down" size={18} />
+                </span>
+              </div>
+            </div>
+
+            <div class="w-full sm:w-auto">
+              <label for="session-select" class="sr-only">Select session</label>
+              <div class="relative">
+                <select
+                  id="session-select"
+                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                >
+                  {
+                    visibleSessions.map((option) => (
+                      <option
+                        value={
+                          option.id === "race"
+                            ? basePath
+                            : `${basePath}/${option.id}`
+                        }
+                        selected={option.id === activeSession}
+                      >
+                        {option.label}
+                      </option>
+                    ))
+                  }
+                </select>
+                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                  <Icon name="mdi:chevron-down" size={18} />
+                </span>
+              </div>
+            </div>
+
+            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-600 p-2 sm:flex">
+              <span class={`fi fi-${flagCode} rounded-sm`} />
+            </div>
+          </div>
+
+          <h1 class="max-w-4xl text-3xl font-black uppercase leading-tight tracking-tight sm:text-5xl">
+            {race.data.raceName} - {activeLabel}
+          </h1>
+
+          <p class="mt-5 text-sm font-bold uppercase text-zinc-300 sm:text-base">
+            {dateLabel}
+          </p>
+          <p class="text-zinc-300">
+            {race.data.trackName}, {race.data.trackLocation}
+          </p>
+
+          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-800 bg-black">
+            <table class="w-full text-sm">
+              <thead class="border-b border-zinc-800">
+                <tr>
+                  {[
+                    "Pos.",
+                    "No.",
+                    "Driver",
+                    "Team",
+                    "Laps",
+                    "Time / Retired",
+                    "Pts.",
+                  ].map((heading) => (
+                    <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-300">
+                      {heading}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  activeRows.length > 0 ? (
+                    activeRows.map((row: ResultRow) => {
+                      const driverSlug = driverSlugByFullName.get(
+                        normalizeName(row.driver),
+                      );
+                      const teamSlug = constructorSlugByName.get(
+                        normalizeName(row.team),
+                      );
+                      return (
+                        <tr class="border-b border-zinc-900 last:border-b-0">
+                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                            {row.position}
+                          </td>
+                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                            {row.carNumber ?? "-"}
+                          </td>
+                          <td class="px-4 py-4 font-semibold text-zinc-100">
+                            {driverSlug ? (
+                              <a
+                                href={`/seasons/${season}/drivers/${driverSlug}`}
+                                class="hover:text-rose-400"
+                              >
+                                {row.driver}
+                              </a>
+                            ) : (
+                              row.driver
+                            )}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">
+                            {teamSlug ? (
+                              <a
+                                href={`/seasons/${season}/constructors/${teamSlug}`}
+                                class="hover:text-rose-400"
+                              >
+                                {row.team}
+                              </a>
+                            ) : (
+                              row.team
+                            )}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">{row.laps ?? "-"}</td>
+                          <td class="px-4 py-4 font-mono text-zinc-100">
+                            {row.timeOrRetired ?? "-"}
+                          </td>
+                          <td class="px-4 py-4 text-zinc-100">{row.points ?? "-"}</td>
+                        </tr>
+                      );
+                    })
+                  ) : (
+                    <tr>
+                      <td colspan={7} class="px-4 py-10 text-center text-zinc-400">
+                        {activeLabel} data is not available yet for this Grand Prix.
+                      </td>
+                    </tr>
+                  )
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+    <Footer />
+
+    <script>
+      const raceSelect = document.getElementById("race-select") as HTMLSelectElement;
+      const sessionSelect = document.getElementById(
+        "session-select",
+      ) as HTMLSelectElement;
+
+      raceSelect?.addEventListener("change", () => {
+        window.location.href = raceSelect.value;
+      });
+
+      sessionSelect?.addEventListener("change", () => {
+        window.location.href = sessionSelect.value;
+      });
+    </script>
+  </body>
+</html>

--- a/src/pages/results/index.astro
+++ b/src/pages/results/index.astro
@@ -1,0 +1,474 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import Breadcrumbs from "../../components/Breadcrumbs.astro";
+import { Icon } from "astro-icon/components";
+import { SITE_TITLE } from "../../consts";
+import { getCollection } from "astro:content";
+
+const season = "2026";
+const normalizeName = (value: string) => value.trim().toLowerCase();
+
+// Races — completed only, sorted by raceNumber
+const allRaces = await getCollection(
+  "races",
+  ({ data }) => data.season === season && data.raceWeekend === "Race",
+);
+const completedRaces = allRaces
+  .filter((r) => r.data.raceCompleted)
+  .sort((a, b) => a.data.raceNumber - b.data.raceNumber);
+
+// Drivers — sorted by championship position
+const drivers = await getCollection(
+  "drivers",
+  ({ data }) => data.season === season,
+);
+const sortedDrivers = [...drivers].sort(
+  (a, b) => a.data.championshipPosition - b.data.championshipPosition,
+);
+
+// Constructors — sorted by championship position
+const constructors = await getCollection(
+  "constructors",
+  ({ data }) => data.season === season,
+);
+const sortedConstructors = [...constructors].sort(
+  (a, b) => a.data.championshipPosition - b.data.championshipPosition,
+);
+
+const driverSlugByFullName = new Map(
+  sortedDrivers.map((driver) => [
+    normalizeName(`${driver.data.driverFirstName} ${driver.data.driverLastName}`),
+    driver.id.split("/").pop() ?? "",
+  ]),
+);
+
+const constructorSlugByName = new Map(
+  sortedConstructors.map((team) => [
+    normalizeName(team.data.constructorName),
+    team.id.split("/").pop() ?? "",
+  ]),
+);
+
+// Country → ISO 3166-1 alpha-2 flag code
+const countryFlagMap: Record<string, string> = {
+  Australia: "au",
+  China: "cn",
+  Japan: "jp",
+  Bahrain: "bh",
+  "Saudi Arabia": "sa",
+  Miami: "us",
+  "Emilia Romagna": "it",
+  Monaco: "mc",
+  Spain: "es",
+  Canada: "ca",
+  Austria: "at",
+  "Great Britain": "gb",
+  Hungary: "hu",
+  Belgium: "be",
+  Netherlands: "nl",
+  Italy: "it",
+  Azerbaijan: "az",
+  Singapore: "sg",
+  "United States": "us",
+  Mexico: "mx",
+  Brazil: "br",
+  "Las Vegas": "us",
+  Qatar: "qa",
+  "Abu Dhabi": "ae",
+};
+---
+
+<!doctype html>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`${season} F1 Results | ${SITE_TITLE}`}
+      description={`${season} Formula 1 season results — races, driver standings, constructor standings and fastest lap awards`}
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Home", href: "/" },
+          { text: "Results" },
+        ]}
+      />
+
+      <section class="container mx-auto mb-12 mt-8 px-4">
+        <!-- Year selector -->
+        <div class="mb-4">
+          <div class="relative inline-block">
+            <select
+              id="year-select"
+              class="cursor-pointer appearance-none rounded-full border border-zinc-300 bg-white py-1.5 pl-4 pr-10 text-sm font-semibold text-zinc-900 shadow-sm transition-colors hover:border-zinc-400 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 dark:hover:border-zinc-500"
+              aria-label="Select season year"
+            >
+              <option value="2026" selected>2026</option>
+              <option value="2025">2025</option>
+              <option value="2024">2024</option>
+            </select>
+            <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+              <Icon name="mdi:chevron-down" size={18} />
+            </span>
+          </div>
+        </div>
+
+        <!-- Tab nav — left-aligned with bottom border -->
+        <div
+          class="mb-8 border-b border-zinc-200 dark:border-zinc-700"
+          role="tablist"
+          aria-label="Results sections"
+        >
+          {
+            [
+              { id: "races", label: "Races" },
+              { id: "drivers", label: "Drivers" },
+              { id: "teams", label: "Teams" },
+              { id: "awards", label: "Awards" },
+            ].map((tab) => (
+              <button
+                role="tab"
+                data-tab={tab.id}
+                class="results-tab relative -mb-px mr-1 px-5 py-2.5 text-sm font-semibold text-zinc-500 cursor-pointer transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                aria-selected="false"
+              >
+                {tab.label}
+              </button>
+            ))
+          }
+        </div>
+
+        <!-- Dynamic heading — updated by JS on tab switch -->
+        <h1
+          id="results-heading"
+          class="mb-6 text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100"
+        >
+          {season} Race Results
+        </h1>
+
+        <!-- ── RACES PANEL ── -->
+        <div id="tab-races" class="results-panel" role="tabpanel">
+          {
+            completedRaces.length === 0 ? (
+              <p class="text-zinc-500 dark:text-zinc-400">
+                No completed races yet.
+              </p>
+            ) : (
+              <div class="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700">
+                <table class="w-full text-sm">
+                  <thead class="bg-zinc-50 dark:bg-zinc-800">
+                    <tr>
+                      {["Grand Prix", "Date", "Winner", "Team", "Laps", "Time"].map(
+                        (h) => (
+                          <th class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+                            {h}
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {completedRaces.map((race) => {
+                      const flagCode =
+                        countryFlagMap[race.data.trackCountry] ?? "un";
+                      const raceSlug = race.id.split("/").pop() ?? "";
+                      const winningDriverSlug = driverSlugByFullName.get(
+                        normalizeName(race.data.winningDriver),
+                      );
+                      const winningConstructorSlug = constructorSlugByName.get(
+                        normalizeName(race.data.winningConstructor),
+                      );
+                      const date = new Date(race.data.raceDate);
+                      const formattedDate = date.toLocaleDateString("en-GB", {
+                        day: "2-digit",
+                        month: "short",
+                      });
+                      return (
+                        <tr class="bg-white transition-colors hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-800/60">
+                          <td class="px-4 py-3">
+                            <a
+                              href={`/results/${season}/races/${raceSlug}`}
+                              class="inline-flex items-center gap-2 font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                            >
+                              <span
+                                class={`fi fi-${flagCode} shrink-0 rounded-sm`}
+                              />
+                              {race.data.trackCountry}
+                            </a>
+                          </td>
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
+                            {formattedDate}
+                          </td>
+                          <td class="px-4 py-3 font-semibold text-zinc-900 dark:text-zinc-100">
+                            {winningDriverSlug ? (
+                              <a
+                                href={`/seasons/${season}/drivers/${winningDriverSlug}`}
+                                class="text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                              >
+                                {race.data.winningDriver}
+                              </a>
+                            ) : (
+                              race.data.winningDriver
+                            )}
+                          </td>
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
+                            {winningConstructorSlug ? (
+                              <a
+                                href={`/seasons/${season}/constructors/${winningConstructorSlug}`}
+                                class="text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                              >
+                                {race.data.winningConstructor}
+                              </a>
+                            ) : (
+                              race.data.winningConstructor
+                            )}
+                          </td>
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
+                            {race.data.laps ?? "—"}
+                          </td>
+                          <td class="px-4 py-3 font-mono text-zinc-900 dark:text-zinc-100">
+                            {race.data.time ?? "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )
+          }
+        </div>
+
+        <!-- ── DRIVERS PANEL ── -->
+        <div id="tab-drivers" class="results-panel hidden" role="tabpanel">
+          <div
+            class="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700"
+          >
+            <table class="w-full text-sm">
+              <thead class="bg-zinc-50 dark:bg-zinc-800">
+                <tr>
+                  {
+                    ["Pos", "Driver", "Nationality", "Team", "Pts"].map((h) => (
+                      <th class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+                        {h}
+                      </th>
+                    ))
+                  }
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                {
+                  sortedDrivers.map((driver) => {
+                    const teamSlug = constructorSlugByName.get(
+                      normalizeName(driver.data.driverTeam),
+                    );
+                    return (
+                    <tr class="bg-white transition-colors hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-800/60">
+                      <td class="w-12 px-4 py-3 font-black text-zinc-900 dark:text-zinc-100">
+                        {driver.data.championshipPosition}
+                      </td>
+                      <td class="px-4 py-3">
+                        <a
+                          href={`/seasons/${season}/drivers/${driver.id.split("/").pop()}`}
+                          class="font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                        >
+                          {driver.data.driverFirstName}{" "}
+                          {driver.data.driverLastName}
+                        </a>
+                      </td>
+                      <td class="px-4 py-3">
+                        <span class="inline-flex items-center gap-2 text-zinc-900 dark:text-zinc-100">
+                          <span
+                            class={`fi fi-${driver.data.countryCode} shrink-0 rounded-sm`}
+                          />
+                          {driver.data.nationality}
+                        </span>
+                      </td>
+                      <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
+                        {teamSlug ? (
+                          <a
+                            href={`/seasons/${season}/constructors/${teamSlug}`}
+                            class="text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                          >
+                            {driver.data.driverTeam}
+                          </a>
+                        ) : (
+                          driver.data.driverTeam
+                        )}
+                      </td>
+                      <td class="px-4 py-3 font-black text-zinc-900 dark:text-zinc-100">
+                        {driver.data.driverPoints}
+                      </td>
+                    </tr>
+                    );
+                  })
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- ── TEAMS PANEL ── -->
+        <div id="tab-teams" class="results-panel hidden" role="tabpanel">
+          <div
+            class="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700"
+          >
+            <table class="w-full text-sm">
+              <thead class="bg-zinc-50 dark:bg-zinc-800">
+                <tr>
+                  {
+                    ["Pos", "Team", "Pts"].map((h) => (
+                      <th class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+                        {h}
+                      </th>
+                    ))
+                  }
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                {
+                  sortedConstructors.map((team) => (
+                    <tr class="bg-white transition-colors hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-800/60">
+                      <td class="w-12 px-4 py-3 font-black text-zinc-900 dark:text-zinc-100">
+                        {team.data.championshipPosition}
+                      </td>
+                      <td class="px-4 py-3">
+                        <a
+                          href={`/seasons/${season}/constructors/${team.id.split("/").pop()}`}
+                          class="font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                        >
+                          {team.data.constructorName}
+                        </a>
+                      </td>
+                      <td class="px-4 py-3 font-black text-zinc-900 dark:text-zinc-100">
+                        {team.data.constructorPoints}
+                      </td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- ── AWARDS PANEL ── -->
+        <div id="tab-awards" class="results-panel hidden" role="tabpanel">
+          {
+            completedRaces.length === 0 ? (
+              <p class="text-zinc-500 dark:text-zinc-400">
+                No completed races yet.
+              </p>
+            ) : (
+              <div class="overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-700">
+                <table class="w-full text-sm">
+                  <thead class="bg-zinc-50 dark:bg-zinc-800">
+                    <tr>
+                      {["Grand Prix", "Driver", "Team", "Fastest Lap"].map(
+                        (h) => (
+                          <th class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+                            {h}
+                          </th>
+                        ),
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {completedRaces.map((race) => {
+                      const flagCode =
+                        countryFlagMap[race.data.trackCountry] ?? "un";
+                      return (
+                        <tr class="bg-white transition-colors hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-800/60">
+                          <td class="px-4 py-3">
+                            <span class="inline-flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                              <span
+                                class={`fi fi-${flagCode} shrink-0 rounded-sm`}
+                              />
+                              {race.data.trackCountry}
+                            </span>
+                          </td>
+                          <td class="px-4 py-3 font-semibold text-zinc-900 dark:text-zinc-100">
+                            {race.data.fastestLapDriver || "—"}
+                          </td>
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
+                            {race.data.fastestLapConstructor || "—"}
+                          </td>
+                          <td class="px-4 py-3 font-mono text-zinc-900 dark:text-zinc-100">
+                            {race.data.fastestLapTime || "—"}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )
+          }
+        </div>
+      </section>
+    </main>
+    <Footer />
+
+    <script>
+      const HEADINGS: Record<string, string> = {
+        races: "2026 Race Results",
+        drivers: "2026 Driver Standings",
+        teams: "2026 Constructor Standings",
+        awards: "2026 DHL Fastest Lap Award",
+      };
+
+      const tabs = document.querySelectorAll<HTMLButtonElement>(".results-tab");
+      const panels =
+        document.querySelectorAll<HTMLDivElement>(".results-panel");
+      const heading = document.getElementById("results-heading");
+
+      function activateTab(id: string) {
+        tabs.forEach((t) => {
+          const active = t.dataset.tab === id;
+          t.setAttribute("aria-selected", String(active));
+          if (active) {
+            t.classList.add(
+              "border-b-2",
+              "border-rose-500",
+              "text-zinc-900",
+              "dark:text-zinc-100",
+            );
+            t.classList.remove("text-zinc-500", "dark:text-zinc-400");
+          } else {
+            t.classList.remove(
+              "border-b-2",
+              "border-rose-500",
+              "text-zinc-900",
+              "dark:text-zinc-100",
+            );
+            t.classList.add("text-zinc-500", "dark:text-zinc-400");
+          }
+        });
+        panels.forEach((p) => {
+          p.classList.toggle("hidden", p.id !== `tab-${id}`);
+        });
+        if (heading && HEADINGS[id]) heading.textContent = HEADINGS[id];
+      }
+
+      activateTab("races");
+
+      tabs.forEach((tab) => {
+        tab.addEventListener("click", () => activateTab(tab.dataset.tab!));
+      });
+
+      // Year dropdown navigation
+      const yearSelect = document.getElementById(
+        "year-select",
+      ) as HTMLSelectElement;
+      yearSelect?.addEventListener("change", () => {
+        window.location.href =
+          yearSelect.value === "2026"
+            ? "/results"
+            : `/results/${yearSelect.value}`;
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
**Summary**
Adds a new standalone Results area with season standings and dynamic race-result session pages.

**What’s Included**

- New results hub page:
  - [index.astro](src/pages/results/index.astro)
  - Year selector + tabs (Races, Drivers, Teams, Awards)
  - Links from table rows to race, driver, and team pages
- New dynamic race results route:
  - [src/pages/results/[season]/races/[raceSlug].astro](src/pages/results/[season]/races/[raceSlug].astro)
  - [src/pages/results/[season]/races/[raceSlug]/[session].astro](src/pages/results/[season]/races/[raceSlug]/[session].astro)
  - Session dropdown supports: Race, Practice 1-3, Qualifying, Sprint, Fastest Laps
  - Sprint option hidden when race content indicates no sprint
- Header nav update:
  - [Header.astro](src/components/Header.astro)
  - Adds top-level Results link and points results links to /results
- Content schema/data updates:
  - [content.config.ts]src/content.config.ts)
  - Added session result arrays and metadata fields ([hasSprint](src/content.config.ts), [raceResults](src/content.config.ts), [practice1Results](src/content.config.ts)
- Seeded initial race content:
  - [australian-gp.md](src/content/races/2026/australian-gp.md)
  - [china-gp.md](src/content/races/2026/china-gp.md)
  - [japan-gp.md](src/content/races/2026/japan-gp.md)

**Notes**

- Pages render fallback “data not available yet” messaging for unseeded sessions.
- Route structure now supports scalable session pages without creating separate template files per session type.