### PR TITLE
feat: backport season page and slug updates across years

### DIFF
--- a/src/pages/seasons/2024/constructors.astro
+++ b/src/pages/seasons/2024/constructors.astro
@@ -55,7 +55,7 @@ const eagerCount = 4;
   <head>
     <BaseHead
       title={`2025 F1 Teams | ${SITE_TITLE}`}
-      description="2025 Formula 1 constructor teams and their cars"
+      description="2024 Formula 1 constructor teams and their cars"
     />
   </head>
   <body>

--- a/src/pages/seasons/2024/constructors/[slug].astro
+++ b/src/pages/seasons/2024/constructors/[slug].astro
@@ -3,9 +3,9 @@ import BaseHead from "../../../../components/BaseHead.astro";
 import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
-import SeasonButtons from "../../../../components/SeasonButtons.astro";
-import StatCard from "../../../../components/StatCard.astro";
+import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
 import DriverCard from "../../../../components/DriverCard.astro";
+import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
 import { getCollection } from "astro:content";
 import { getSlugFromEntry } from "../../../../utils/slugUtils";
@@ -28,6 +28,7 @@ const { team } = Astro.props;
 // Import the Content component separately
 import { render } from "astro:content";
 import { Image } from "astro:assets";
+import { teamBgMap } from "../../../../utils/teamBgMap";
 const { Content } = await render(team);
 
 // Get all drivers for 2024 season
@@ -41,13 +42,78 @@ drivers.forEach((driver) => {
   const fullName = `${driver.data.driverFirstName} ${driver.data.driverLastName}`;
   driverMap.set(fullName, driver);
 });
+// team background image (optional)
+const teamBg = teamBgMap[team.data.constructorName] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[team.data.constructorName] || "rgb(244 63 94)";
+const teamCode = team.data.constructorName
+  .split(" ")
+  .map((word) => word[0])
+  .join("")
+  .slice(0, 3)
+  .toUpperCase();
+
+// Hero stats grid items
+const heroStats = [
+  { value: team.data.teamPrincipal, label: "Team Principal" },
+  { value: team.data.carModel, label: "Chassis" },
+  { value: team.data.championshipPosition, label: "Championship Position" },
+  { value: team.data.engineSupplier, label: "Power Unit" },
+];
+
+// 2024 Season stats
+const seasonStats = [
+  { value: team.data.championshipPosition, label: "Championship Position" },
+  { value: team.data.constructorPoints, label: "Constructor Points" },
+  { value: team.data.racesEntered, label: "Races Entered" },
+  { value: team.data.grandPrixPoints, label: "Grand Prix Points" },
+  { value: team.data.grandPrixWins, label: "Grand Prix Wins" },
+  { value: team.data.podiumPositions, label: "Grand Prix Podiums" },
+  { value: team.data.polePositions, label: "Grand Prix Poles" },
+  { value: team.data.dnf, label: "DNFs" },
+  { value: team.data.sprintWins, label: "Sprint Wins" },
+  { value: team.data.sprintPoints, label: "Sprint Points" },
+  { value: team.data.sprintPolePositions, label: "Sprint Poles" },
+  { value: team.data.sprintPodiums, label: "Sprint Podiums" },
+];
+
+// Lifetime stats
+const lifetimeStats = [
+  { value: team.data.careerStats?.firstEntry, label: "First Entry" },
+  { value: team.data.careerStats?.racesEntered, label: "Races Entered" },
+  { value: team.data.careerStats?.grandPrixWins, label: "Grand Prix Wins" },
+  { value: team.data.careerStats?.careerPoints, label: "Career Points" },
+  { value: team.data.careerStats?.polePositions, label: "Pole Positions" },
+  { value: team.data.careerStats?.podiumPositions, label: "Podiums" },
+  {
+    value: team.data.careerStats?.constructorChampionships,
+    label: "Constructor Championships",
+  },
+  {
+    value: team.data.careerStats?.driverChampionships,
+    label: "Driver Championships",
+  },
+];
 ---
 
 <!doctype html>
 <html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
   <head>
     <BaseHead
-      title={`${team.data.constructorName} | ${SITE_TITLE}`}
+      title={`2024 ${team.data.constructorName} Team Profile | ${SITE_TITLE}`}
       description={`2024 F1 team profile for ${team.data.constructorName} with their ${team.data.carModel} car`}
     />
   </head>
@@ -56,53 +122,70 @@ drivers.forEach((driver) => {
     <main>
       <Breadcrumbs
         items={[
-          { text: "Formula 1", href: "/" },
+          { text: "Home", href: "/" },
           { text: "Seasons", href: "/seasons/" },
-          { text: "2024 Season", href: "/seasons/2024/" },
+          { text: "2024", href: "/seasons/2024/" },
           { text: "Constructors", href: "/seasons/2024/constructors" },
           { text: `${team.data.constructorName}` },
         ]}
       />
       <!-- Team Profile Header -->
-      <section class="bg-zinc-100 py-16 dark:bg-zinc-900">
-        <div class="container mx-auto px-4">
-          <div class="grid grid-cols-1 items-center gap-8 lg:grid-cols-2">
-            <div>
-              <Image
-                src={team.data.carImage || "/blog-placeholder-1.jpg"}
-                alt={`${team.data.constructorName} ${team.data.carModel}`}
-                class="w-full rounded-lg"
-              />
+      <section class="container mb-8 mt-12">
+        <div
+          class="team-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Team Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {teamCode}
+              </p>
+              <div class="flex flex-1 p-6 pt-12">
+                <Image
+                  src={team.data.carImageLarge || team.data.carImage}
+                  alt={team.data.carImageLargeAlt || team.data.carImageAlt}
+                  width={600}
+                  height={600}
+                  class="h-full w-full object-contain"
+                  loading="eager"
+                />
+              </div>
             </div>
-            <div>
-              <h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">
+
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2024 Constructor Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
                 {team.data.constructorName}
               </h1>
-              <div class="space-y-3 text-lg">
-                <div class="flex items-center">
-                  <span class="w-40 dark:text-zinc-400">Car Model:</span>
-                  <span class="text-zinc-700 dark:text-zinc-300"
-                    >{team.data.carModel}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-40 dark:text-zinc-400">Team Principal:</span>
-                  <span class="text-zinc-700 dark:text-zinc-300"
-                    >{team.data.teamPrincipal}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-40 dark:text-zinc-400">Engine:</span>
-                  <span class="text-zinc-700 dark:text-zinc-300"
-                    >{team.data.engineSupplier}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-40 dark:text-zinc-400">Drivers:</span>
-                  <span class="text-zinc-700 dark:text-zinc-300"
-                    >{team.data.teamDrivers.join(", ")}</span
-                  >
-                </div>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
+                    </div>
+                  ))
+                }
               </div>
             </div>
           </div>
@@ -110,7 +193,7 @@ drivers.forEach((driver) => {
       </section>
 
       <!-- Team Drivers Section -->
-      <section class="bg-white py-12 dark:bg-zinc-900">
+      <section class="bg-zinc-100 py-12 dark:bg-zinc-900">
         <div class="container mx-auto">
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Team Drivers
@@ -124,7 +207,7 @@ drivers.forEach((driver) => {
                     driver={driver}
                     index={i}
                     year={team.data.season}
-                    eagerCount={2}
+                    eagerCount={0}
                   />
                 ) : null;
               })
@@ -133,185 +216,65 @@ drivers.forEach((driver) => {
         </div>
       </section>
 
-      <!-- Team Statistics -->
-      <section class="hidden bg-zinc-100 py-12 dark:bg-zinc-900">
-        <div class="container mx-auto">
-          <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
-            2024 Season Statistics
-          </h2>
-          <div class="mx-auto max-w-7xl">
-            <div class="-mx-2 flex flex-wrap">
-              <div class="mb-6 w-1/2 px-4 md:w-1/4">
-                <StatCard
-                  value={team.data.championshipPosition}
-                  label="Championship Position"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.constructorPoints}
-                  label="Constructor Points"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard value={team.data.grandPrixWins} label="Race Wins" />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.polePositions}
-                  label="Pole Positions"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard value={team.data.fastestLaps} label="Fastest Laps" />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.sprintPodiums}
-                  label="Sprint Podiums"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.sprintPoints}
-                  label="Sprint Points"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard value={team.data.sprintWins} label="Sprint Wins" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Lifetime Statistics -->
-      <section class="hidden bg-zinc-100 py-12 dark:bg-zinc-900">
-        <div class="container mx-auto">
-          <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
-            Lifetime Statistics
-          </h2>
-          <div class="mx-auto max-w-7xl">
-            <div class="-mx-2 flex flex-wrap">
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.careerStats?.constructorChampionships}
-                  label="Championships"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.careerStats?.grandPrixWins}
-                  label="Race Wins"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.careerStats?.polePositions}
-                  label="Pole Positions"
-                />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={team.data.careerStats?.fastestLaps}
-                  label="Fastest Laps"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
       <!-- Two Column Statistics Section -->
       <section class="bg-zinc-100 py-12 dark:bg-zinc-900">
-        <div class="container mx-auto">
+        <div class="container mx-auto px-4">
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Team Statistics
           </h2>
-          <div class="mx-auto grid max-w-7xl grid-cols-1 gap-8 md:grid-cols-2">
-            {/* Team Statistics Column */}
-            <div>
-              <h3
-                class="mb-4 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                2024 Season Statistics
-              </h3>
-              <div class="-mx-2 flex flex-wrap px-4">
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.championshipPosition}
-                    label="Championship Position"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.constructorPoints}
-                    label="Constructor Points"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard value={team.data.grandPrixWins} label="Race Wins" />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.polePositions}
-                    label="Pole Positions"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.fastestLaps}
-                    label="Fastest Laps"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.sprintPodiums}
-                    label="Sprint Podiums"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.sprintPoints}
-                    label="Sprint Points"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard value={team.data.sprintWins} label="Sprint Wins" />
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
+            {/* Season Statistics Column */}
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2024 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
                 </div>
               </div>
             </div>
             {/* Lifetime Statistics Column */}
-            <div>
-              <h3
-                class="mb-4 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                Lifetime Statistics
-              </h3>
-              <div class="-mx-2 flex flex-wrap px-4">
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.careerStats?.constructorChampionships}
-                    label="Championships"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.careerStats?.grandPrixWins}
-                    label="Race Wins"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.careerStats?.polePositions}
-                    label="Pole Positions"
-                  />
-                </div>
-                <div class="mb-6 w-1/2 px-2 md:w-1/2">
-                  <StatCard
-                    value={team.data.careerStats?.fastestLaps}
-                    label="Fastest Laps"
-                  />
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
                 </div>
               </div>
             </div>
@@ -322,15 +285,87 @@ drivers.forEach((driver) => {
       <!-- Team Information -->
       <section class="bg-zinc-100 py-12 dark:bg-zinc-900">
         <div class="container mx-auto">
-          <div class="prose prose-lg dark:prose-invert max-w-none">
+          <div
+            class="prose prose-lg dark:prose-invert text-zinc-800 dark:text-zinc-300"
+          >
             <Content />
           </div>
         </div>
       </section>
 
-      <!-- Back Links -->
-      <SeasonButtons season="2024" />
+      {/* Last Updated Section */}
+      <section class="py-8">
+        <p class="text-zinc-600 dark:text-zinc-400">
+          {
+            team.data.updatedDate && (
+              <>
+                Last updated:{" "}
+                <FormattedDate date={new Date(team.data.updatedDate)} />
+              </>
+            )
+          }
+        </p>
+      </section>
+
+      <!-- Back Link -->
+      <SeasonButtonsModular
+        leftHref="/seasons/2024/constructors/"
+        leftText="Back to 2024 Constructors"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .team-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/seasons/2024/drivers/[slug].astro
+++ b/src/pages/seasons/2024/drivers/[slug].astro
@@ -3,8 +3,8 @@ import BaseHead from "../../../../components/BaseHead.astro";
 import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
-import StatCard from "../../../../components/StatCard.astro";
-import SeasonButtons from "../../../../components/SeasonButtons.astro";
+import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
+import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
 import { getCollection } from "astro:content";
 import { getSlugFromEntry } from "../../../../utils/slugUtils";
@@ -26,14 +26,64 @@ export async function getStaticPaths() {
 const { driver } = Astro.props;
 // Import the Content component separately
 import { render } from "astro:content";
+import { Image } from "astro:assets";
+import { teamBgMap } from "../../../../utils/teamBgMap";
 const { Content } = await render(driver);
+// team background for driver's team
+const teamBg = teamBgMap[driver.data.driverTeam] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[driver.data.driverTeam] || "rgb(244 63 94)";
+const driverCode = `${driver.data.driverFirstName?.[0] ?? ""}${driver.data.driverLastName?.[0] ?? ""}`.toUpperCase();
+
+// Hero stats grid items
+const heroStats = [
+  { value: driver.data.driverTeam, label: "Team" },
+  { value: driver.data.nationality, label: "Nationality" },
+  { value: driver.data.age, label: "Age" },
+  { value: driver.data.championshipPosition, label: "Championship Position" },
+  { value: driver.data.driverPoints, label: "Points" },
+  { value: driver.data.grandPrixWins, label: "Grand Prix Wins" },
+];
+
+// Season stats for StatCard section
+const seasonStats = [
+  { value: driver.data.championshipPosition, label: "Championship Position" },
+  { value: driver.data.driverPoints, label: "Driver Points" },
+  { value: driver.data.grandPrixWins, label: "Grand Prix Wins" },
+  { value: driver.data.polePositions, label: "Pole Positions" },
+  { value: driver.data.fastestLaps, label: "Fastest Laps" },
+  { value: driver.data.podiums, label: "Podiums" },
+];
+
+// Lifetime stats for StatCard section
+const lifetimeStats = [
+  { value: driver.data.careerStats?.championships, label: "Championships" },
+  { value: driver.data.careerStats?.careerPoints, label: "Career Points" },
+  { value: driver.data.careerStats?.grandPrixWins, label: "Grand Prix Wins" },
+  { value: driver.data.careerStats?.polePositions, label: "Pole Positions" },
+  { value: driver.data.careerStats?.fastestLaps, label: "Fastest Laps" },
+  { value: driver.data.careerStats?.podiumPositions, label: "Podiums" },
+];
 ---
 
 <!doctype html>
 <html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
   <head>
     <BaseHead
-      title={`${driver.data.driverFirstName} ${driver.data.driverLastName} | ${SITE_TITLE}`}
+      title={`2024 ${driver.data.driverFirstName} ${driver.data.driverLastName} Driver Profile | ${SITE_TITLE}`}
       description={`2024 F1 driver profile for ${driver.data.driverFirstName} ${driver.data.driverLastName} driving for ${driver.data.driverTeam}`}
     />
   </head>
@@ -43,7 +93,8 @@ const { Content } = await render(driver);
       <Breadcrumbs
         items={[
           { text: "Home", href: "/" },
-          { text: "2024 Season", href: "/seasons/2024/" },
+          { text: "Seasons", href: "/seasons/" },
+          { text: "2024", href: "/seasons/2024/" },
           { text: "Drivers", href: "/seasons/2024/drivers" },
           {
             text: `${driver.data.driverFirstName} ${driver.data.driverLastName}`,
@@ -51,79 +102,128 @@ const { Content } = await render(driver);
         ]}
       />
 
-      <!-- Driver Profile Header -->
-      <section class="bg-zinc-100 py-16 dark:bg-zinc-900">
-        <div class="container mx-auto">
-          <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-            <div>
-              <img
-                src={driver.data.profileImageLarge?.src ??
-                  driver.data.profileImage?.src ??
-                  "/blog-placeholder-1.jpg"}
-                alt={`${driver.data.driverFirstName} ${driver.data.driverLastName} Profile Image`}
-                class=""
-                loading="lazy"
+      <!-- driver slug hero -->
+      <section class="container mx-auto mb-8 mt-12">
+        <div
+          class="driver-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 items-end justify-end overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Driver Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {driverCode}
+              </p>
+              <Image
+                src={driver.data.profileImageLarge || driver.data.profileImage}
+                alt={driver.data.profileImageLargeAlt ||
+                  driver.data.profileImageAlt}
+                width={400}
+                height={400}
+                class="relative z-10 object-contain object-bottom"
+                loading="eager"
               />
             </div>
-            <div>
-              <h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">
-                {driver.data.driverFirstName}
-                <span class="">{driver.data.driverLastName}</span>
+
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2024 Driver Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
+                {driver.data.driverFirstName} {driver.data.driverLastName}
               </h1>
-              <div class="space-y-3 text-lg">
-                <div class="flex items-center">
-                  <span class="w-32 dark:text-zinc-400">Number:</span>
-                  <span class="dark:text-zinc-400"
-                    >#{driver.data.driverNumber}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-32 dark:text-zinc-400">Team:</span>
-                  <span class="dark:text-zinc-400"
-                    >{driver.data.driverTeam}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-32 dark:text-zinc-400">Nationality:</span>
-                  <span class="dark:text-zinc-400"
-                    >{driver.data.nationality}</span
-                  >
-                </div>
-                <div class="flex items-center">
-                  <span class="w-32 dark:text-zinc-400">Age:</span>
-                  <span class="dark:text-zinc-400">{driver.data.age}</span>
-                </div>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
+                    </div>
+                  ))
+                }
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <!-- Driver Statistics -->
+      <!-- Two Column Statistics Section -->
       <section class="bg-zinc-100 py-12 dark:bg-zinc-900">
-        <div class="container mx-auto">
+        <div class="container mx-auto px-4">
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
-            Career Statistics
+            Driver Statistics
           </h2>
-          <div class="mx-auto max-w-7xl">
-            <div class="-mx-2 flex flex-wrap">
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={driver.data.championships}
-                  label="Championships"
-                />
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
+            {/* Season Statistics Column */}
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2024 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard value={driver.data.grandPrixWins} label="Race Wins" />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard value={driver.data.podiums} label="Podiums" />
-              </div>
-              <div class="mb-6 w-1/2 px-2 md:w-1/4">
-                <StatCard
-                  value={driver.data.driverPoints}
-                  label="Career Points"
-                />
+            </div>
+            {/* Lifetime Statistics Column */}
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
           </div>
@@ -133,15 +233,87 @@ const { Content } = await render(driver);
       <!-- Driver Biography -->
       <section class="bg-zinc-100 py-12 dark:bg-zinc-900">
         <div class="container mx-auto">
-          <div class="prose prose-lg dark:prose-invert max-w-none">
+          <div
+            class="prose prose-lg dark:prose-invert text-zinc-800 dark:text-zinc-300"
+          >
             <Content />
           </div>
         </div>
       </section>
 
-      <!-- Back Links -->
-      <SeasonButtons season="2024" />
+      {/* Last Updated Section */}
+      <section class="container mx-auto py-8">
+        <p class="text-zinc-600 dark:text-zinc-400">
+          {
+            driver.data.updatedDate && (
+              <>
+                Last updated:{" "}
+                <FormattedDate date={new Date(driver.data.updatedDate)} />
+              </>
+            )
+          }
+        </p>
+      </section>
+
+      {/* Back Link */}
+      <SeasonButtonsModular
+        leftHref="/seasons/2024/drivers/"
+        leftText="Back to 2024 Drivers"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .driver-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/seasons/2025/constructors/[slug].astro
+++ b/src/pages/seasons/2025/constructors/[slug].astro
@@ -4,7 +4,6 @@ import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
 import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
-import StatCard from "../../../../components/StatCard.astro";
 import DriverCard from "../../../../components/DriverCard.astro";
 import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
@@ -45,6 +44,27 @@ drivers.forEach((driver) => {
 });
 // team background image (optional)
 const teamBg = teamBgMap[team.data.constructorName] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[team.data.constructorName] || "rgb(244 63 94)";
+const teamCode = team.data.constructorName
+  .split(" ")
+  .map((word) => word[0])
+  .join("")
+  .slice(0, 3)
+  .toUpperCase();
 
 // Hero stats grid items
 const heroStats = [
@@ -110,47 +130,63 @@ const lifetimeStats = [
         ]}
       />
       <!-- Team Profile Header -->
-      <section
-        class="container mb-8 mt-12 rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-950"
-      >
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-          <!-- Left: Car Image -->
-          <div
-            class="flex flex-1 overflow-hidden rounded-2xl"
-            style={teamBg
-              ? `background-image: url('${teamBg.src}'); background-size: cover;`
-              : ""}
-          >
-            <div class="flex flex-1 p-6">
-              <Image
-                src={team.data.carImageLarge || team.data.carImage}
-                alt={team.data.carImageLargeAlt || team.data.carImageAlt}
-                width={600}
-                height={600}
-                class="h-full w-full object-contain"
-                loading="eager"
-              />
+      <section class="container mb-8 mt-12">
+        <div
+          class="team-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Team Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {teamCode}
+              </p>
+              <div class="flex flex-1 p-6 pt-12">
+                <Image
+                  src={team.data.carImageLarge || team.data.carImage}
+                  alt={team.data.carImageLargeAlt || team.data.carImageAlt}
+                  width={600}
+                  height={600}
+                  class="h-full w-full object-contain"
+                  loading="eager"
+                />
+              </div>
             </div>
-          </div>
-          <!-- Right: Constructor Info & Stats -->
-          <div class="space-y-4">
-            <h1 class="font-bold text-zinc-900 dark:text-zinc-100">
-              {team.data.constructorName}
-            </h1>
-            <!-- Stats Grid -->
-            <div class="grid gap-4 sm:grid-cols-2">
-              {
-                heroStats.map((stat) => (
-                  <div class="rounded-xl bg-zinc-200/50 p-4 text-center dark:bg-zinc-800">
-                    <div class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                      {stat.value}
+
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2025 Constructor Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
+                {team.data.constructorName}
+              </h1>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
                     </div>
-                    <div class="text-base text-zinc-800 dark:text-zinc-400">
-                      {stat.label}
-                    </div>
-                  </div>
-                ))
-              }
+                  ))
+                }
+              </div>
             </div>
           </div>
         </div>
@@ -186,35 +222,60 @@ const lifetimeStats = [
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Team Statistics
           </h2>
-          <div class="mx-auto grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
             {/* Season Statistics Column */}
-            <div class="rounded-xl p-6">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                2025 Season
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  seasonStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2025 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
             {/* Lifetime Statistics Column */}
-            <div class="rounded-xl bg-zinc-200/50 p-6 dark:bg-zinc-700/70">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                Lifetime
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  lifetimeStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
           </div>
@@ -232,16 +293,8 @@ const lifetimeStats = [
         </div>
       </section>
 
-      <!-- Back Link -->
-      <SeasonButtonsModular
-        leftHref="/seasons/2025/constructors/"
-        leftText="Back to 2025 Constructors"
-        rightHref="/seasons"
-        rightText="Back to Seasons"
-      />
-
       {/* Last Updated Section */}
-      <section class="pt-12 text-center">
+      <section class="py-8">
         <p class="text-zinc-600 dark:text-zinc-400">
           {
             team.data.updatedDate && (
@@ -253,7 +306,66 @@ const lifetimeStats = [
           }
         </p>
       </section>
+
+      <!-- Back Link -->
+      <SeasonButtonsModular
+        leftHref="/seasons/2025/constructors/"
+        leftText="Back to 2025 Constructors"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .team-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/seasons/2025/drivers.astro
+++ b/src/pages/seasons/2025/drivers.astro
@@ -57,7 +57,7 @@ const sortedDrivers = drivers.sort((a, b) => {
       <!-- Drivers Grid -->
       <section class="pb-16 pt-4">
         <div class="container mx-auto">
-          <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
             {
               sortedDrivers.map((driver, i) => (
                 <DriverCard

--- a/src/pages/seasons/2025/drivers/[slug].astro
+++ b/src/pages/seasons/2025/drivers/[slug].astro
@@ -3,7 +3,6 @@ import BaseHead from "../../../../components/BaseHead.astro";
 import Header from "../../../../components/Header.astro";
 import Footer from "../../../../components/Footer.astro";
 import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
-import StatCard from "../../../../components/StatCard.astro";
 import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
 import FormattedDate from "../../../../components/FormattedDate.astro";
 import { SITE_TITLE } from "../../../../consts";
@@ -32,6 +31,22 @@ import { teamBgMap } from "../../../../utils/teamBgMap";
 const { Content } = await render(driver);
 // team background for driver's team
 const teamBg = teamBgMap[driver.data.driverTeam] || null;
+const teamAccentMap: Record<string, string> = {
+  McLaren: "rgb(249 115 22)",
+  Ferrari: "rgb(220 38 38)",
+  Mercedes: "rgb(20 184 166)",
+  Williams: "rgb(37 99 235)",
+  "Red Bull Racing": "rgb(59 130 246)",
+  "Kick Sauber": "rgb(34 197 94)",
+  "Racing Bulls": "rgb(6 182 212)",
+  "Aston Martin": "rgb(16 185 129)",
+  Haas: "rgb(239 68 68)",
+  Alpine: "rgb(14 165 233)",
+  Cadillac: "rgb(244 63 94)",
+  Audi: "rgb(220 38 38)",
+};
+const teamAccent = teamAccentMap[driver.data.driverTeam] || "rgb(244 63 94)";
+const driverCode = `${driver.data.driverFirstName?.[0] ?? ""}${driver.data.driverLastName?.[0] ?? ""}`.toUpperCase();
 
 // Hero stats grid items
 const heroStats = [
@@ -88,48 +103,62 @@ const lifetimeStats = [
       />
 
       <!-- driver slug hero -->
-      <section
-        class="mb-8 mt-12 rounded-2xl bg-white p-6 shadow-lg dark:bg-zinc-950"
-      >
-        <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-          <!-- Left: Driver Image with team background -->
-          <div
-            class="flex flex-1 items-end justify-end overflow-hidden rounded-2xl"
-            style={teamBg
-              ? `background-image: url('${teamBg.src}'); background-size: cover; background-position: center;`
-              : ""}
-          >
-            <Image
-              src={driver.data.profileImageLarge || driver.data.profileImage}
-              alt={driver.data.profileImageLargeAlt ||
-                driver.data.profileImageAlt}
-              width={400}
-              height={400}
-              class="object-contain object-bottom"
-              loading="eager"
-            />
-          </div>
-          <!-- Right: Driver Info & Stats -->
-          <div>
-            <h1 class="mb-2 font-bold text-zinc-900 dark:text-zinc-100">
-              {driver.data.driverFirstName}
-              {driver.data.driverLastName}
-            </h1>
+      <section class="container mx-auto mb-8 mt-12">
+        <div
+          class="driver-profile-shell relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/90 p-6 shadow-lg dark:border-zinc-700/70 dark:bg-zinc-900/80"
+          style={`--team-accent:${teamAccent};`}
+        >
+          <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+          <div class="relative z-10 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+          <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+          <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+          <div class="relative z-10 grid grid-cols-1 gap-8 pt-5 lg:grid-cols-2">
+            <div
+              class="relative flex flex-1 items-end justify-end overflow-hidden rounded-md border border-zinc-300/60 dark:border-zinc-700/60"
+              style={teamBg
+                ? `background-image: linear-gradient(to top, rgb(9 9 11 / 0.78), rgb(9 9 11 / 0.2)), url('${teamBg.src}'); background-size: cover; background-position: center;`
+                : ""}
+            >
+              <div class="absolute left-4 top-4 z-20 inline-flex items-center gap-2 rounded-sm border border-zinc-200/35 bg-zinc-950/55 px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-zinc-100">
+                <span class="h-1.5 w-1.5 rounded-full bg-zinc-300"></span>
+                Driver Profile
+              </div>
+              <p class="pointer-events-none absolute bottom-3 left-3 z-10 text-7xl font-black uppercase tracking-tight text-zinc-100/14 md:text-8xl">
+                {driverCode}
+              </p>
+              <Image
+                src={driver.data.profileImageLarge || driver.data.profileImage}
+                alt={driver.data.profileImageLargeAlt ||
+                  driver.data.profileImageAlt}
+                width={400}
+                height={400}
+                class="relative z-10 object-contain object-bottom"
+                loading="eager"
+              />
+            </div>
 
-            <!-- Stats Grid -->
-            <div class="grid grid-cols-2 gap-4">
-              {
-                heroStats.map((stat) => (
-                  <div class="rounded-xl bg-zinc-200/50 p-4 text-center dark:bg-zinc-800">
-                    <div class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                      {stat.value}
+            <div class="space-y-4">
+              <p class="text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-400">
+                2025 Driver Briefing
+              </p>
+              <h1 class="text-4xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100 md:text-5xl">
+                {driver.data.driverFirstName} {driver.data.driverLastName}
+              </h1>
+
+              <div class="grid gap-3 sm:grid-cols-2">
+                {
+                  heroStats.map((stat) => (
+                    <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-4 dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                      <div class="text-lg font-black text-zinc-900 dark:text-zinc-100 md:text-xl">
+                        {stat.value}
+                      </div>
+                      <div class="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                        {stat.label}
+                      </div>
                     </div>
-                    <div class="text-base text-zinc-800 dark:text-zinc-400">
-                      {stat.label}
-                    </div>
-                  </div>
-                ))
-              }
+                  ))
+                }
+              </div>
             </div>
           </div>
         </div>
@@ -141,35 +170,60 @@ const lifetimeStats = [
           <h2 class="mb-8 text-center text-3xl font-bold dark:text-zinc-200">
             Driver Statistics
           </h2>
-          <div class="mx-auto grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-2">
+          <div
+            class="mx-auto grid max-w-6xl grid-cols-1 gap-6 lg:grid-cols-2"
+            style={`--team-accent:${teamAccent};`}
+          >
             {/* Season Statistics Column */}
-            <div class="rounded-xl p-6">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                2025 Season
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  seasonStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  2025 Season
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    seasonStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
             {/* Lifetime Statistics Column */}
-            <div class="rounded-xl bg-zinc-200/50 p-6 dark:bg-zinc-700/70">
-              <h3
-                class="mb-6 text-center text-xl font-semibold dark:text-zinc-100"
-              >
-                Lifetime
-              </h3>
-              <div class="grid grid-cols-2 gap-4">
-                {
-                  lifetimeStats.map((stat) => (
-                    <StatCard value={stat.value} label={stat.label} />
-                  ))
-                }
+            <div class="stats-panel relative overflow-hidden rounded-md border border-zinc-300/80 bg-white/85 p-6 dark:border-zinc-700/70 dark:bg-zinc-900/80">
+              <div class="panel-grid-overlay pointer-events-none absolute inset-0 z-1"></div>
+              <div class="relative z-10">
+                <div class="mb-3 h-1.5 w-full bg-linear-to-r from-transparent via-(--team-accent) to-transparent"></div>
+                <div class="panel-corner panel-corner-top" aria-hidden="true"></div>
+                <div class="panel-corner panel-corner-bottom" aria-hidden="true"></div>
+                <h3 class="mb-6 text-center text-xl font-black uppercase tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Lifetime
+                </h3>
+                <div class="grid grid-cols-2 gap-3">
+                  {
+                    lifetimeStats.map((stat) => (
+                      <div class="rounded-md border border-zinc-300/80 bg-zinc-50/85 p-3 text-center dark:border-zinc-700/70 dark:bg-zinc-800/75">
+                        <div class="text-xl font-black text-zinc-900 dark:text-zinc-100">
+                          {stat.value}
+                        </div>
+                        <div class="mt-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-zinc-600 dark:text-zinc-400">
+                          {stat.label}
+                        </div>
+                      </div>
+                    ))
+                  }
+                </div>
               </div>
             </div>
           </div>
@@ -187,16 +241,8 @@ const lifetimeStats = [
         </div>
       </section>
 
-      <!-- Back Link -->
-      <SeasonButtonsModular
-        leftHref="/seasons/2025/drivers/"
-        leftText="Back to 2025 Drivers"
-        rightHref="/seasons"
-        rightText="Back to Seasons"
-      />
-
       {/* Last Updated Section */}
-      <section class="pt-12 text-center">
+      <section class="container mx-auto py-8">
         <p class="text-zinc-600 dark:text-zinc-400">
           {
             driver.data.updatedDate && (
@@ -208,7 +254,66 @@ const lifetimeStats = [
           }
         </p>
       </section>
+
+      {/* Back Link */}
+      <SeasonButtonsModular
+        leftHref="/seasons/2025/drivers/"
+        leftText="Back to 2025 Drivers"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
     </main>
     <Footer />
+
+    <style>
+      .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(0 0 0 / 0.02) 0,
+          rgb(0 0 0 / 0.02) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .panel-grid-overlay {
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgb(255 255 255 / 0.22) 0,
+          rgb(255 255 255 / 0.22) 2px,
+          transparent 2px,
+          transparent 12px
+        );
+      }
+
+      :global(.dark) .driver-profile-shell,
+      :global(.dark) .stats-panel {
+        background-color: rgb(9 9 11 / 0.9);
+      }
+
+      .panel-corner {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-top: 1px solid rgb(0 0 0 / 0.14);
+        opacity: 0.85;
+      }
+
+      .panel-corner-top {
+        right: 9px;
+        top: 9px;
+        transform: skew(18deg);
+      }
+
+      .panel-corner-bottom {
+        left: 9px;
+        bottom: 9px;
+        transform: skew(-18deg);
+      }
+
+      :global(.dark) .panel-corner {
+        border-top-color: rgb(255 255 255 / 0.16);
+      }
+    </style>
   </body>
 </html>

--- a/src/pages/seasons/2025/races.astro
+++ b/src/pages/seasons/2025/races.astro
@@ -1,63 +1,59 @@
 ---
-import BaseHead from "../../../components/BaseHead.astro"
-import Header from "../../../components/Header.astro"
-import Footer from "../../../components/Footer.astro"
-import Breadcrumbs from "../../../components/Breadcrumbs.astro"
-import RaceCalendar from "../../../components/RaceCalendar.astro"
-import SeasonButtonsModular from "../../../components/SeasonButtonsModular.astro"
-import { SITE_TITLE } from "../../../consts"
+import BaseHead from "../../../components/BaseHead.astro";
+import Header from "../../../components/Header.astro";
+import Footer from "../../../components/Footer.astro";
+import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import RaceCalendar from "../../../components/RaceCalendar.astro";
+import SeasonButtonsModular from "../../../components/SeasonButtonsModular.astro";
+import { SITE_TITLE } from "../../../consts";
 ---
 
 <!doctype html>
-<html
-	lang="en"
-	class="bg-zinc-100 dark:bg-zinc-900">
-	<head>
-		<BaseHead
-			title={`2025 F1 Races | ${SITE_TITLE}`}
-			description="Complete list of races for the 2025 Formula 1 season"
-		/>
-	</head>
-	<body>
-		<Header />
-		<main>
-			<Breadcrumbs
-				items={[
-					{ text: "Home", href: "/" },
-					{ text: "Seasons", href: "/seasons" },
-					{ text: "2025 Season", href: "/seasons/2025/" },
-					{ text: "Races", href: "/seasons/2025/races" },
-				]}
-			/>
-			<!-- 2025 Races Header -->
-			<section class="pt-16 text-center">
-				<div class="container mx-auto px-4">
-					<h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">2025 Formula 1 Races</h1>
-					<p class="text-lg text-zinc-700 dark:text-zinc-300">
-						Complete race calendar for the 2025 season
-					</p>
-				</div>
-			</section>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`2025 F1 Races | ${SITE_TITLE}`}
+      description="Complete list of races for the 2025 Formula 1 season"
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Home", href: "/" },
+          { text: "Seasons", href: "/seasons" },
+          { text: "2025 Season", href: "/seasons/2025/" },
+          { text: "Races", href: "/seasons/2025/races" },
+        ]}
+      />
+      <!-- 2025 Races Header -->
+      <section class="pt-16 text-center">
+        <div class="container mx-auto px-4">
+          <h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">
+            2025 Formula 1 Races
+          </h1>
+          <p class="text-lg text-zinc-700 dark:text-zinc-300">
+            Complete race calendar for the 2025 season
+          </p>
+        </div>
+      </section>
 
-			<!-- Race Calendar -->
-			<section class="py-6">
-				<div class="container mx-auto px-4">
-					<RaceCalendar
-						season="2025"
-						showAllRaces={true}
-						eagerCount={6}
-					/>
-				</div>
-			</section>
+      <!-- Race Calendar -->
+      <section class="py-6">
+        <div class="container mx-auto px-4">
+          <RaceCalendar season="2025" showAllRaces={true} eagerCount={6} />
+        </div>
+      </section>
 
-			<!-- Back Link -->
-			<SeasonButtonsModular
-				leftHref="/seasons/2025/"
-				leftText="Back to 2025 Season"
-				rightHref="/seasons"
-				rightText="Back to Seasons"
-			/>
-		</main>
-		<Footer />
-	</body>
+      <!-- Back Link -->
+      <SeasonButtonsModular
+        leftHref="/seasons/2025/"
+        leftText="Back to 2025 Season"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
+    </main>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/seasons/2025/races/[slug].astro
+++ b/src/pages/seasons/2025/races/[slug].astro
@@ -1,154 +1,168 @@
 ---
-import { getCollection } from "astro:content"
-import BaseHead from "../../../../components/BaseHead.astro"
-import Header from "../../../../components/Header.astro"
-import Footer from "../../../../components/Footer.astro"
-import FormattedDate from "../../../../components/FormattedDate.astro"
-import Breadcrumbs from "../../../../components/Breadcrumbs.astro"
-import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro"
-import { SITE_TITLE } from "../../../../consts"
-import { getSlugFromEntry } from "../../../../utils/slugUtils"
+import { getCollection } from "astro:content";
+import BaseHead from "../../../../components/BaseHead.astro";
+import Header from "../../../../components/Header.astro";
+import Footer from "../../../../components/Footer.astro";
+import FormattedDate from "../../../../components/FormattedDate.astro";
+import Breadcrumbs from "../../../../components/Breadcrumbs.astro";
+import SeasonButtonsModular from "../../../../components/SeasonButtonsModular.astro";
+import { SITE_TITLE } from "../../../../consts";
+import { getSlugFromEntry } from "../../../../utils/slugUtils";
 
 export async function getStaticPaths() {
-	const races = await getCollection("races", ({ data }) => {
-		return data.season === "2025"
-	})
+  const races = await getCollection("races", ({ data }) => {
+    return data.season === "2025";
+  });
 
-	return races.map((race) => {
-		const slug = getSlugFromEntry(race)
-		return {
-			params: { slug },
-			props: { race },
-		}
-	})
+  return races.map((race) => {
+    const slug = getSlugFromEntry(race);
+    return {
+      params: { slug },
+      props: { race },
+    };
+  });
 }
 
-const { race } = Astro.props
+const { race } = Astro.props;
 // Import the Content component
-import { render } from "astro:content"
-const { Content } = await render(race)
+import { render } from "astro:content";
+const { Content } = await render(race);
 ---
 
 <!doctype html>
-<html
-	lang="en"
-	class="bg-zinc-100 dark:bg-zinc-900">
-	<head>
-		<BaseHead
-			title={`${race.data.trackName} | ${SITE_TITLE}`}
-			description={`Information about the ${race.data.trackName} Grand Prix of the 2025 Formula 1 season`}
-		/>
-	</head>
-	<body>
-		<Header />
-		<main>
-			<Breadcrumbs
-				items={[
-					{ text: "Formula 1", href: "/" },
-					{ text: "Seasons", href: "/seasons/" },
-					{ text: "2025", href: "/seasons/2025/" },
-					{ text: "Races", href: "/seasons/2025/races" },
-					{ text: `${race.data.raceName}` },
-				]}
-			/>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`${race.data.trackName} | ${SITE_TITLE}`}
+      description={`Information about the ${race.data.trackName} Grand Prix of the 2025 Formula 1 season`}
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Formula 1", href: "/" },
+          { text: "Seasons", href: "/seasons/" },
+          { text: "2025", href: "/seasons/2025/" },
+          { text: "Races", href: "/seasons/2025/races" },
+          { text: `${race.data.raceName}` },
+        ]}
+      />
 
-			<!-- Race Header - Left aligned without background -->
-			<section class="race-header pt-12">
-				<div class="container mx-auto px-4">
-					<h1 class="mb-2 text-4xl font-bold dark:text-zinc-100">
-						{race.data.raceName}
-					</h1>
-					<p class="text-zinc-700 dark:text-zinc-400">
-						<FormattedDate date={race.data.raceDate} /> • {race.data.trackLocation}
-					</p>
-				</div>
-			</section>
+      <!-- Race Header - Left aligned without background -->
+      <section class="race-header pt-12">
+        <div class="container mx-auto px-4">
+          <h1 class="mb-2 text-4xl font-bold dark:text-zinc-100">
+            {race.data.raceName}
+          </h1>
+          <p class="text-zinc-700 dark:text-zinc-400">
+            <FormattedDate date={race.data.raceDate} /> • {
+              race.data.trackLocation
+            }
+          </p>
+        </div>
+      </section>
 
-			<!-- Race Status -->
-			<section class="py-4">
-				<div class="container mx-auto px-4">
-					<div class="text-left">
-						{
-							race.data.raceCompleted ?
-								<span class="inline-block rounded border border-green-400 bg-green-200 px-4 py-2 text-green-800 transition-colors duration-300 dark:border-green-600 dark:bg-green-700 dark:text-white dark:hover:bg-green-800">
-									Race Completed
-								</span>
-							:	<span class="inline-block rounded border border-zinc-400 bg-zinc-200 px-4 py-2 text-zinc-800 transition-colors duration-300 dark:border-amber-600 dark:bg-amber-700 dark:text-white dark:hover:bg-amber-800">
-									Upcoming Race
-								</span>
-						}
-					</div>
-				</div>
-			</section>
+      <!-- Race Status -->
+      <section class="py-4">
+        <div class="container mx-auto px-4">
+          <div class="text-left">
+            {
+              race.data.raceCompleted ? (
+                <span class="inline-block rounded border border-green-400 bg-green-200 px-4 py-2 text-green-800 transition-colors duration-300 dark:border-green-600 dark:bg-green-700 dark:text-white dark:hover:bg-green-800">
+                  Race Completed
+                </span>
+              ) : (
+                <span class="inline-block rounded border border-zinc-400 bg-zinc-200 px-4 py-2 text-zinc-800 transition-colors duration-300 dark:border-amber-600 dark:bg-amber-700 dark:text-white dark:hover:bg-amber-800">
+                  Upcoming Race
+                </span>
+              )
+            }
+          </div>
+        </div>
+      </section>
 
-			<!-- Race Details -->
-			<section class="py-8">
-				<div class="container mx-auto px-4">
-					<!-- Race Stats -->
-					<div class="mb-8 rounded-lg border border-zinc-300 p-6 dark:border-zinc-600">
-						<h2 class="mb-4 text-2xl font-bold dark:text-zinc-200">Race Details</h2>
-						<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-							<div>
-								<ul class="space-y-3">
-									<li class="flex justify-between">
-										<span class="dark:text-zinc-200">Date:</span>
-										<span class="text-zinc-600 dark:text-zinc-300"
-											><FormattedDate date={race.data.raceDate} /></span
-										>
-									</li>
-									<li class="flex justify-between">
-										<span class="dark:text-zinc-200">Location:</span>
-										<span class="text-zinc-600 dark:text-zinc-300">{race.data.trackLocation}</span>
-									</li>
-									<li class="flex justify-between">
-										<span class="dark:text-zinc-200">Race Number:</span>
-										<span class="text-zinc-600 dark:text-zinc-300">{race.data.raceNumber}</span>
-									</li>
-								</ul>
-							</div>
+      <!-- Race Details -->
+      <section class="py-8">
+        <div class="container mx-auto px-4">
+          <!-- Race Stats -->
+          <div
+            class="mb-8 rounded-lg border border-zinc-300 p-6 dark:border-zinc-600"
+          >
+            <h2 class="mb-4 text-2xl font-bold dark:text-zinc-200">
+              Race Details
+            </h2>
+            <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+              <div>
+                <ul class="space-y-3">
+                  <li class="flex justify-between">
+                    <span class="dark:text-zinc-200">Date:</span>
+                    <span class="text-zinc-600 dark:text-zinc-300"
+                      ><FormattedDate date={race.data.raceDate} /></span
+                    >
+                  </li>
+                  <li class="flex justify-between">
+                    <span class="dark:text-zinc-200">Location:</span>
+                    <span class="text-zinc-600 dark:text-zinc-300"
+                      >{race.data.trackLocation}</span
+                    >
+                  </li>
+                  <li class="flex justify-between">
+                    <span class="dark:text-zinc-200">Race Number:</span>
+                    <span class="text-zinc-600 dark:text-zinc-300"
+                      >{race.data.raceNumber}</span
+                    >
+                  </li>
+                </ul>
+              </div>
 
-							{
-								race.data.raceCompleted && (
-									<div>
-										<ul class="space-y-3">
-											<li class="flex justify-between">
-												<span class="dark:text-zinc-200">Winner:</span>
-												<span class="text-zinc-600 dark:text-zinc-300">
-													{race.data.winningDriver}
-												</span>
-											</li>
-											<li class="flex justify-between">
-												<span class="dark:text-zinc-200">Winning Team:</span>
-												<span class="text-zinc-600 dark:text-zinc-300">
-													{race.data.winningConstructor}
-												</span>
-											</li>
-											<li class="flex justify-between">
-												<span class="dark:text-zinc-200">Time:</span>
-												<span class="text-zinc-600 dark:text-zinc-300">{race.data.time}</span>
-											</li>
-										</ul>
-									</div>
-								)
-							}
-						</div>
-					</div>
+              {
+                race.data.raceCompleted && (
+                  <div>
+                    <ul class="space-y-3">
+                      <li class="flex justify-between">
+                        <span class="dark:text-zinc-200">Winner:</span>
+                        <span class="text-zinc-600 dark:text-zinc-300">
+                          {race.data.winningDriver}
+                        </span>
+                      </li>
+                      <li class="flex justify-between">
+                        <span class="dark:text-zinc-200">Winning Team:</span>
+                        <span class="text-zinc-600 dark:text-zinc-300">
+                          {race.data.winningConstructor}
+                        </span>
+                      </li>
+                      <li class="flex justify-between">
+                        <span class="dark:text-zinc-200">Time:</span>
+                        <span class="text-zinc-600 dark:text-zinc-300">
+                          {race.data.time}
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                )
+              }
+            </div>
+          </div>
 
-					<!-- Race Content -->
-					<div class="race-content prose dark:prose-invert leading-loose! text-zinc-800 dark:text-zinc-300">
-						<Content />
-					</div>
-				</div>
-			</section>
+          <!-- Race Content -->
+          <div
+            class="race-content prose dark:prose-invert leading-loose! text-zinc-800 dark:text-zinc-300"
+          >
+            <Content />
+          </div>
+        </div>
+      </section>
 
-			<!-- Back Links -->
-			<SeasonButtonsModular
-				leftHref="/seasons/2025/races/"
-				leftText="Back to 2025 Races"
-				rightHref="/seasons"
-				rightText="Back to Seasons"
-			/>
-		</main>
-		<Footer />
-	</body>
+      <!-- Back Links -->
+      <SeasonButtonsModular
+        leftHref="/seasons/2025/races/"
+        leftText="Back to 2025 Races"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
+    </main>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/seasons/2026/drivers.astro
+++ b/src/pages/seasons/2026/drivers.astro
@@ -8,40 +8,30 @@ import { SITE_TITLE } from "../../../consts";
 import { getCollection } from "astro:content";
 import SeasonButtonsModular from "../../../components/SeasonButtonsModular.astro";
 
-// Get all drivers for 2026 season
+// Get all drivers and constructors for 2026 season
 const drivers = await getCollection("drivers", ({ data }) => {
   return data.season === "2026";
 });
 
-// Sort drivers by championship position (1-24)
-const sortedByStandings = [...drivers].sort((a, b) => {
-  if (a.data.championshipPosition !== b.data.championshipPosition) {
-    return a.data.championshipPosition - b.data.championshipPosition;
-  }
-  return b.data.driverPoints - a.data.driverPoints;
+const constructors = await getCollection("constructors", ({ data }) => {
+  return data.season === "2026";
 });
 
-// Group drivers by team (sorted alphabetically by team name)
-const teamOrder = [
-  "Alpine",
-  "Aston Martin",
-  "Audi",
-  "Cadillac",
-  "Ferrari",
-  "Haas",
-  "McLaren",
-  "Mercedes",
-  "Racing Bulls",
-  "Red Bull Racing",
-  "Williams",
-];
+// Create a map of team name to championship position
+const teamChampionshipMap = new Map(
+  constructors.map((c) => [
+    c.data.constructorName,
+    c.data.championshipPosition,
+  ]),
+);
 
+// Sort drivers by team championship position, then by driver number
 const sortedByTeam = [...drivers].sort((a, b) => {
-  const teamA = teamOrder.indexOf(a.data.driverTeam);
-  const teamB = teamOrder.indexOf(b.data.driverTeam);
-  if (teamA !== teamB) return teamA - teamB;
-  // Within same team, sort by driver number or name
-  return a.data.driverLastName.localeCompare(b.data.driverLastName);
+  const teamPosA = teamChampionshipMap.get(a.data.driverTeam) || 999;
+  const teamPosB = teamChampionshipMap.get(b.data.driverTeam) || 999;
+  if (teamPosA !== teamPosB) return teamPosA - teamPosB;
+  // Within same team, sort by driver number
+  return a.data.driverNumber - b.data.driverNumber;
 });
 
 const eagerCount = 4;
@@ -75,53 +65,13 @@ const eagerCount = 4;
           <p class="text-lg text-gray-800 dark:text-zinc-300">
             Complete driver profiles and season statistics
           </p>
-
-          <!-- Sort Toggle -->
-          <div class="mt-8 flex justify-center gap-2">
-            <button
-              id="sort-standings"
-              class="sort-btn rounded-lg bg-zinc-200 px-4 py-2 text-sm font-medium text-zinc-700 transition-all duration-200 hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600"
-              data-active="false"
-            >
-              By Standings
-            </button>
-            <button
-              id="sort-team"
-              class="sort-btn rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white transition-all duration-200"
-              data-active="true"
-            >
-              By Team
-            </button>
-          </div>
         </div>
       </section>
 
-      <!-- Drivers Grid - By Standings -->
-      <section id="grid-standings" class="hidden pb-16 pt-4">
+      <!-- Drivers Grid -->
+      <section id="drivers-grid" class="pb-16 pt-4">
         <div class="container mx-auto">
-          <div
-            class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-          >
-            {
-              sortedByStandings.map((driver, i) => (
-                <DriverCard
-                  driver={driver}
-                  index={i}
-                  eagerCount={eagerCount}
-                  year="2026"
-                />
-              ))
-            }
-          </div>
-        </div>
-      </section>
-
-      <!-- Drivers Grid - By Team -->
-      <section id="grid-team" class="pb-16 pt-4">
-        <div class="container mx-auto">
-          <div
-            class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-          >
+          <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
             {
               sortedByTeam.map((driver, i) => (
                 <DriverCard
@@ -145,50 +95,5 @@ const eagerCount = 4;
       />
     </main>
     <Footer />
-
-    <script>
-      const btnStandings = document.getElementById("sort-standings");
-      const btnTeam = document.getElementById("sort-team");
-      const gridStandings = document.getElementById("grid-standings");
-      const gridTeam = document.getElementById("grid-team");
-
-      const activeClasses = ["bg-sky-600", "text-white"];
-      const inactiveClasses = [
-        "bg-zinc-200",
-        "text-zinc-700",
-        "hover:bg-zinc-300",
-        "dark:bg-zinc-700",
-        "dark:text-zinc-300",
-        "dark:hover:bg-zinc-600",
-      ];
-
-      function setActive(
-        activeBtn: HTMLElement,
-        inactiveBtn: HTMLElement,
-        showGrid: HTMLElement,
-        hideGrid: HTMLElement,
-      ) {
-        // Update button styles
-        activeBtn.classList.remove(...inactiveClasses);
-        activeBtn.classList.add(...activeClasses);
-        activeBtn.dataset.active = "true";
-
-        inactiveBtn.classList.remove(...activeClasses);
-        inactiveBtn.classList.add(...inactiveClasses);
-        inactiveBtn.dataset.active = "false";
-
-        // Toggle grids
-        showGrid.classList.remove("hidden");
-        hideGrid.classList.add("hidden");
-      }
-
-      btnStandings?.addEventListener("click", () => {
-        setActive(btnStandings, btnTeam!, gridStandings!, gridTeam!);
-      });
-
-      btnTeam?.addEventListener("click", () => {
-        setActive(btnTeam, btnStandings!, gridTeam!, gridStandings!);
-      });
-    </script>
   </body>
 </html>

--- a/src/pages/seasons/2026/index.astro
+++ b/src/pages/seasons/2026/index.astro
@@ -21,7 +21,7 @@ const isDevMode = import.meta.env.DEV;
     />
   </head>
   <body>
-    s <Header />
+    <Header />
     <main>
       <Breadcrumbs
         items={[
@@ -31,7 +31,7 @@ const isDevMode = import.meta.env.DEV;
         ]}
       />
 
-      <!-- 2025 Season Header -->
+      <!-- 2026 Season Header -->
       <section class="pb-6 pt-6 text-center dark:text-zinc-100">
         <div class="container mx-auto px-4">
           <h1 class="mb-4 text-4xl font-bold">State of the Season</h1>

--- a/src/pages/seasons/2026/races.astro
+++ b/src/pages/seasons/2026/races.astro
@@ -1,64 +1,59 @@
 ---
-import BaseHead from "../../../components/BaseHead.astro"
-import Header from "../../../components/Header.astro"
-import Footer from "../../../components/Footer.astro"
-import Breadcrumbs from "../../../components/Breadcrumbs.astro"
-import RaceCalendar from "../../../components/RaceCalendar.astro"
-import SeasonButtonsModular from "../../../components/SeasonButtonsModular.astro"
-import { SITE_TITLE } from "../../../consts"
+import BaseHead from "../../../components/BaseHead.astro";
+import Header from "../../../components/Header.astro";
+import Footer from "../../../components/Footer.astro";
+import Breadcrumbs from "../../../components/Breadcrumbs.astro";
+import RaceCalendar from "../../../components/RaceCalendar.astro";
+import SeasonButtonsModular from "../../../components/SeasonButtonsModular.astro";
+import { SITE_TITLE } from "../../../consts";
 ---
 
 <!doctype html>
-<html
-	lang="en"
-	class="bg-zinc-100 dark:bg-zinc-900">
-	<head>
-		<BaseHead
-			title={`2026 F1 Races | ${SITE_TITLE}`}
-			description="Complete list of races for the 2026 Formula 1 season"
-		/>
-	</head>
-	<body>
+<html lang="en" class="bg-zinc-100 dark:bg-zinc-900">
+  <head>
+    <BaseHead
+      title={`2026 F1 Races | ${SITE_TITLE}`}
+      description="Complete list of races for the 2026 Formula 1 season"
+    />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <Breadcrumbs
+        items={[
+          { text: "Home", href: "/" },
+          { text: "Seasons", href: "/seasons" },
+          { text: "2026 Season", href: "/seasons/2026/" },
+          { text: "Races", href: "/seasons/2026/races" },
+        ]}
+      />
+      <!-- 2025 Races Header -->
+      <section class="pt-16 text-center">
+        <div class="container mx-auto px-4">
+          <h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">
+            2026 Formula 1 Races
+          </h1>
+          <p class="text-lg text-zinc-800 dark:text-zinc-300">
+            Complete race calendar for the 2026 season
+          </p>
+        </div>
+      </section>
 
-		<Header />
-		<main>
-			<Breadcrumbs
-				items={[
-					{ text: "Home", href: "/" },
-					{ text: "Seasons", href: "/seasons" },
-					{ text: "2026 Season", href: "/seasons/2026/" },
-					{ text: "Races", href: "/seasons/2026/races" },
-				]}
-			/>
-			<!-- 2025 Races Header -->
-			<section class="pt-16 text-center">
-				<div class="container mx-auto px-4">
-					<h1 class="mb-4 text-4xl font-bold dark:text-zinc-100">2026 Formula 1 Races</h1>
-					<p class="text-lg text-zinc-800 dark:text-zinc-300">
-						Complete race calendar for the 2026 season
-					</p>
-				</div>
-			</section>
+      <!-- Race Calendar -->
+      <section class="py-6">
+        <div class="container mx-auto px-4">
+          <RaceCalendar season="2026" showAllRaces={true} eagerCount={6} />
+        </div>
+      </section>
 
-			<!-- Race Calendar -->
-			<section class="py-6">
-				<div class="container mx-auto px-4">
-					<RaceCalendar
-						season="2026"
-						showAllRaces={true}
-						eagerCount={6}
-					/>
-				</div>
-			</section>
-
-			<!-- Back Link -->
-			<SeasonButtonsModular
-				leftHref="/seasons/2026/"
-				leftText="Back to 2026 Season"
-				rightHref="/seasons"
-				rightText="Back to Seasons"
-			/>
-		</main>
-		<Footer />
-	</body>
+      <!-- Back Link -->
+      <SeasonButtonsModular
+        leftHref="/seasons/2026/"
+        leftText="Back to 2026 Season"
+        rightHref="/seasons"
+        rightText="Back to Seasons"
+      />
+    </main>
+    <Footer />
+  </body>
 </html>

--- a/src/pages/seasons/index.astro
+++ b/src/pages/seasons/index.astro
@@ -42,8 +42,8 @@ import { Icon } from "astro-icon/components";
           <div class="md:col-span-2 dark:text-zinc-100">
             <Image
               src={teams25Img}
-              alt="2026 F1 Season China"
-              class="w-full"
+              alt="2026 F1 Season Miami"
+              class="w-full rounded"
               loading="eager"
             />
             <div class="flex grow flex-col py-4">
@@ -82,7 +82,7 @@ import { Icon } from "astro-icon/components";
             <Image
               src={teams25Img}
               alt="2025 F1 Season China"
-              class="w-full"
+              class="w-full rounded"
               loading="eager"
             />
             <div class="flex grow flex-col py-4">
@@ -120,8 +120,8 @@ import { Icon } from "astro-icon/components";
           <div class="dark:text-zinc-100">
             <Image
               src={teams24Img}
-              alt="2025 F1 Season Monaco"
-              class="w-full"
+              alt="2024 F1 Season Monaco"
+              class="w-full rounded"
               loading="eager"
             />
             <div class="py-4">


### PR DESCRIPTION
**Summary**
Backports season page and slug-page improvements across 2024 and 2025, while aligning related season navigation pages with the updated direction used in newer season work.

**What Changed**

- Updated season-level pages for consistency across years
- Backported key slug-page layout/structure improvements to older seasons
- Aligned season index/race/driver/constructor page presentation for smoother cross-season UX
- 
**Files**
- [index.astro](src/pages/seasons/index.astro)

- [src/pages/seasons/2024/constructors/[slug].astro](src/pages/seasons/2024/constructors.astro)
- [src/pages/seasons/2024/drivers/[slug].astro](src/pages/seasons/2024/drivers.astro)
- [src/pages/seasons/2025/constructors/[slug].astro](src/pages/seasons/2025/constructors/[slug].astro)

- [src/pages/seasons/2025/drivers/[slug].astro](src/pages/seasons/2025/drivers/[slug].astro)

- [src/pages/seasons/2025/races/[slug].astro](src/pages/seasons/2025/races/[slug].astro)

- [index.astro](src/pages/seasons/2026/index.astro)
- [races.astro](src/pages/seasons/2026/races.astro)

**Notes**
This PR is intentionally scoped to season page/backport work only.
Results feature work and component refresh are tracked in separate branches/PRs for easier review.