### PR TITLE
feat: expand 2026 race sessions and results rendering

### DIFF
--- a/src/components/RaceCard.astro
+++ b/src/components/RaceCard.astro
@@ -21,6 +21,7 @@ const nowUTC = toUTCMidnight(new Date());
 const raceDateUTC = toUTCMidnight(new Date(race.data.raceDate));
 const sevenDaysFromNowUTC = new Date(nowUTC);
 sevenDaysFromNowUTC.setDate(nowUTC.getDate() + 7);
+const isRaceCompleted = race.data.raceCompleted || raceDateUTC < nowUTC;
 
 const lastCompletedRaceDate =
   completedRaces.length > 0
@@ -35,7 +36,7 @@ const currentSeason = new Date().getFullYear().toString();
 const isCurrentSeason = race.data.season === currentSeason;
 const isPreviousRace =
   isCurrentSeason &&
-  race.data.raceCompleted &&
+  isRaceCompleted &&
   raceDateUTC.getTime() === lastCompletedRaceDate;
 
 const raceDateObj = new Date(race.data.raceDate);
@@ -76,7 +77,7 @@ const getStatusLabel = () => {
       iconToneClass: "text-sky-600 dark:text-sky-400",
     };
   }
-  if (race.data.raceCompleted) {
+  if (isRaceCompleted) {
     return {
       label: "Completed",
       chipClass: "border-emerald-300/90 bg-emerald-500 text-white",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,11 @@
 import { glob } from "astro/loaders";
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { z } from "astro/zod";
+
+const resultPositionSchema = z.union([
+  z.number(),
+  z.enum(["NC", "DNS", "DSQ", "DNQ", "DNF"]),
+]);
 
 const blog = defineCollection({
   // Load Markdown and MDX files in the `src/content/blog/` directory.
@@ -130,7 +136,7 @@ const races = defineCollection({
       raceResults: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
@@ -143,51 +149,67 @@ const races = defineCollection({
       practice1Results: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
             laps: z.number().optional(),
-            timeOrRetired: z.string().optional(),
-            points: z.number().optional(),
+            timeOrGap: z.string().optional(),
           }),
         )
         .optional(),
       practice2Results: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
             laps: z.number().optional(),
-            timeOrRetired: z.string().optional(),
-            points: z.number().optional(),
+            timeOrGap: z.string().optional(),
           }),
         )
         .optional(),
       practice3Results: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
             laps: z.number().optional(),
-            timeOrRetired: z.string().optional(),
-            points: z.number().optional(),
+            timeOrGap: z.string().optional(),
           }),
         )
         .optional(),
       qualifyingResults: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
             laps: z.number().optional(),
-            timeOrRetired: z.string().optional(),
+            timeOrGap: z.string().optional(),
+            q1: z.string().optional(),
+            q2: z.string().optional(),
+            q3: z.string().optional(),
+            points: z.number().optional(),
+          }),
+        )
+        .optional(),
+      sprintQualifyingResults: z
+        .array(
+          z.object({
+            position: resultPositionSchema,
+            carNumber: z.number().optional(),
+            driver: z.string(),
+            team: z.string(),
+            laps: z.number().optional(),
+            timeOrGap: z.string().optional(),
+            sq1: z.string().optional(),
+            sq2: z.string().optional(),
+            sq3: z.string().optional(),
             points: z.number().optional(),
           }),
         )
@@ -195,7 +217,7 @@ const races = defineCollection({
       sprintResults: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),
@@ -208,7 +230,7 @@ const races = defineCollection({
       fastestLapResults: z
         .array(
           z.object({
-            position: z.number(),
+            position: resultPositionSchema,
             carNumber: z.number().optional(),
             driver: z.string(),
             team: z.string(),

--- a/src/content/constructors/2026/alpine.md
+++ b/src/content/constructors/2026/alpine.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Alpine 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Alpine 2026 Constructor car"
-carModel: "A525"
+carModel: "A526"
 careerStats:
   firstEntry: 1986
   racesEntered: 388
@@ -19,7 +19,7 @@ constructorName: "Alpine"
 constructorPoints: 16
 dnf: 0
 description: "Alpine team description"
-engineSupplier: "Renault"
+engineSupplier: "Mercedes"
 fastestLaps: 10
 grandPrixWins: 0
 grandPrixPoints: 0

--- a/src/content/constructors/2026/aston-martin.md
+++ b/src/content/constructors/2026/aston-martin.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Aston Martin 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Aston Martin 2026 Constructor car"
-carModel: "AMR25"
+carModel: "AMR26"
 careerStats:
   firstEntry: 1959
   racesEntered: 148
@@ -19,7 +19,7 @@ constructorName: "Aston Martin"
 constructorPoints: 0
 dnf: 0
 description: "Aston Martin team description"
-engineSupplier: "Mercedes"
+engineSupplier: "Honda"
 fastestLaps: 0
 grandPrixWins: 0
 grandPrixPoints: 0

--- a/src/content/constructors/2026/audi.md
+++ b/src/content/constructors/2026/audi.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Audi 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Audi 2026 Constructor car"
-carModel: ""
+carModel: "R26"
 careerStats:
   firstEntry: 1993
   racesEntered: 611
@@ -19,7 +19,7 @@ constructorName: "Audi"
 constructorPoints: 2
 dnf: 0
 description: "Audi team description"
-engineSupplier: "Ferrari"
+engineSupplier: "Audi"
 fastestLaps: 0
 grandPrixWins: 0
 grandPrixPoints: 0

--- a/src/content/constructors/2026/cadillac.md
+++ b/src/content/constructors/2026/cadillac.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Cadillac 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Cadillac 2026 Constructor car"
-carModel: "CAD-01"
+carModel: "MAC-26"
 careerStats:
   firstEntry: 2026
   racesEntered: 0
@@ -13,7 +13,7 @@ careerStats:
 constructorName: "Cadillac"
 constructorPoints: 0
 description: "Cadillac joins the Formula 1 grid with a manufacturer-backed effort focused on sustainable powertrain development and a high-downforce chassis package."
-engineSupplier: "Cadillac"
+engineSupplier: "Ferrari"
 championshipPosition: 10
 season: "2026"
 teamDrivers: ["Sergio Perez", "Valtteri Bottas"]

--- a/src/content/constructors/2026/ferrari.md
+++ b/src/content/constructors/2026/ferrari.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Ferrari 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Ferrari 2026 Constructor car"
-carModel: "SF-25"
+carModel: "SF-26"
 careerStats:
   firstEntry: 1950
   racesEntered: 1119

--- a/src/content/constructors/2026/haas.md
+++ b/src/content/constructors/2026/haas.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Haas 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Haas 2026 Constructor car"
-carModel: "VF-25"
+carModel: "VF-26"
 careerStats:
   firstEntry: 2016
   racesEntered: 210

--- a/src/content/constructors/2026/mclaren.md
+++ b/src/content/constructors/2026/mclaren.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "McLaren 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "McLaren 2026 Constructor car"
-carModel: "MCL39"
+carModel: "MCL40"
 careerStats:
   firstEntry: 1966
   racesEntered: 994

--- a/src/content/constructors/2026/mercedes.md
+++ b/src/content/constructors/2026/mercedes.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Mercedes 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Mercedes 2026 Constructor car"
-carModel: "W16"
+carModel: "W17"
 careerStats:
   firstEntry: 1954
   racesEntered: 325

--- a/src/content/constructors/2026/racing-bulls.md
+++ b/src/content/constructors/2026/racing-bulls.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Racing Bulls 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Racing Bulls 2026 Constructor car"
-carModel: "VCARB 02"
+carModel: "VCARB 03"
 careerStats:
   firstEntry: 2004
   racesEntered: 395
@@ -19,7 +19,7 @@ constructorName: "Racing Bulls"
 constructorPoints: 14
 dnf: 0
 description: "Racing Bulls team description"
-engineSupplier: "Honda RBPT"
+engineSupplier: "Red Bull Ford"
 fastestLaps: 0
 grandPrixWins: 0
 grandPrixPoints: 0

--- a/src/content/constructors/2026/red-bull-racing.md
+++ b/src/content/constructors/2026/red-bull-racing.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Red Bull Racing 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Red Bull Racing 2026 Constructor car"
-carModel: "RB21"
+carModel: "RB22"
 careerStats:
   firstEntry: 2005
   racesEntered: 412
@@ -19,7 +19,7 @@ constructorName: "Red Bull Racing"
 constructorPoints: 15
 dnf: 0
 description: "Red Bull Racing team description"
-engineSupplier: "Honda RBPT"
+engineSupplier: "Red Bull Ford"
 fastestLaps: 0
 grandPrixWins: 0
 grandPrixPoints: 0

--- a/src/content/constructors/2026/williams.md
+++ b/src/content/constructors/2026/williams.md
@@ -3,7 +3,7 @@ carImage: "../../../assets/car-2026-placeholder.png"
 carImageAlt: "Williams 2026 Constructor car"
 carImageLarge: "../../../assets/car-2026-placeholder.png"
 carImageLargeAlt: "Williams 2026 Constructor car"
-carModel: "RB21"
+carModel: "FW48"
 careerStats:
   firstEntry: 1977
   racesEntered: 847

--- a/src/content/races/2026/abu-dhabi-gp.md
+++ b/src/content/races/2026/abu-dhabi-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 24
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/australian-gp.md
+++ b/src/content/races/2026/australian-gp.md
@@ -66,6 +66,654 @@ raceResults:
     laps: 58
     timeOrRetired: "+54.617s"
     points: 8
+  - position: 7
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 6
+  - position: 8
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 4
+  - position: 9
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 2
+  - position: 10
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 1
+  - position: 11
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 12
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 13
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 57
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 14
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 56
+    timeOrRetired: "+2 laps"
+    points: 0
+  - position: 15
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 56
+    timeOrRetired: "+2 laps"
+    points: 0
+  - position: 16
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 55
+    timeOrRetired: "+3 laps"
+    points: 12
+  - position: NC
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 43
+    timeOrRetired: "+18 laps"
+    points: 0
+  - position: NC
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 21
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 15
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 0
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+  - position: NC
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Haas"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+practice1Results: 
+  - position: 1
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 33
+    timeOrGap: "1.20.267s"
+  - position: 2
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 30
+    timeOrGap: "+0.469s"
+  - position: 3
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 27
+    timeOrGap: "+0.522s"
+  - position: 4
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 24
+    timeOrGap: "+0.820s"
+  - position: 5
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 22
+    timeOrGap: "+1.046s"
+  - position: 6
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 21
+    timeOrGap: "+1.075s"
+  - position: 7
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 26
+    timeOrGap: "+1.104s"
+  - position: 8
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 24
+    timeOrGap: "+1.109s"
+  - position: 9
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 23
+    timeOrGap: "+1.429s"
+  - position: 10
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 21
+    timeOrGap: "+1.702s"
+  - position: 11
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 28
+    timeOrGap: "+1.894s"
+  - position: 12
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 30
+    timeOrGap: "+2.056s"
+  - position: 13
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 28
+    timeOrGap: "+2.346s"
+  - position: 14
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 25
+    timeOrGap: "+2.415s"
+  - position: 15
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 24
+    timeOrGap: "+2.863s"
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 26
+    timeOrGap: "+3.058s"
+  - position: 17
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 24
+    timeOrGap: "+3.755s"
+  - position: 18
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 27
+    timeOrGap: "+3.768s"
+    points: 0
+  - position: 19
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 7
+    timeOrGap: "+4.124s"
+  - position: 20
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 14
+    timeOrGap: "+4.353s"
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 3
+    timeOrGap: "+30.067s"
+practice2Results:
+  - position: 1
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 26
+    timeOrGap: "1.19.729s"
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 31
+    timeOrGap: "+0.214s"
+  - position: 3
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 28
+    timeOrGap: "+0.320s"
+  - position: 4
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 32
+    timeOrGap: "+0.321s"
+  - position: 5
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 30
+    timeOrGap: "+0.562s"
+  - position: 6
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 13
+    timeOrGap: "+0.637s"
+  - position: 7
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 29
+    timeOrGap: "+1.065s"
+  - position: 8
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 30
+    timeOrGap: "+1.193s"
+  - position: 9
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 28
+    timeOrGap: "+1.212s"
+  - position: 10
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 29
+    timeOrGap: "+1.450s"
+  - position: 11
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 31
+    timeOrGap: "+1.597s"
+  - position: 12
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 34
+    timeOrGap: "+1.622s"
+  - position: 13
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 29
+    timeOrGap: "+1.629s"
+  - position: 14
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 28
+    timeOrGap: "+1.939s"
+  - position: 15
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 32
+    timeOrGap: "+2.118s"
+  - position: 16
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 16
+    timeOrGap: "+2.438s"
+  - position: 17
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 10
+    timeOrGap: "+2.524s"
+  - position: 18
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 27
+    timeOrGap: "+2.890s"
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 28
+    timeOrGap: "+3.931s"
+  - position: 20
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 18
+    timeOrGap: "+4.933s"
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 13
+    timeOrGap: "+6.087s"
+practice3Results: 
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 23
+    timeOrGap: "1.19.053"
+  - position: 2
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 22
+    timeOrGap: "+0.616s"
+  - position: 3
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 20
+    timeOrGap: "+0.774s"
+  - position: 4
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 17
+    timeOrGap: "+1.034s"
+  - position: 5
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 15
+    timeOrGap: "+1.084s"
+  - position: 6
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 15
+    timeOrGap: "+1.144s"
+  - position: 7
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 18
+    timeOrGap: "+1.271s"
+  - position: 8
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 22
+    timeOrGap: "+1.390s"
+  - position: 9
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 19
+    timeOrGap: "+1.406s"
+  - position: 10
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 18
+    timeOrGap: "+1.725s"
+  - position: 11
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 15
+    timeOrGap: "+1.785s"
+  - position: 12
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 13
+    timeOrGap: "+1.837s"
+  - position: 13
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 19
+    timeOrGap: "+1.930s"
+  - position: 14
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 22
+    timeOrGap: "+2.014s"
+  - position: 15
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 26
+    timeOrGap: "+2.018s"
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 22
+    timeOrGap: "+2.360s"
+  - position: 17
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 17
+    timeOrGap: "+2.611s"
+  - position: 18
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 20
+    timeOrGap: "+3.667s"
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 12
+    timeOrGap: "+4.461s"
+  - position: 20
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 21
+    timeOrGap: "+5.344s"
+  - position: 21
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 1
+    timeOrGap: ""
+qualifyingResults:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    q1: "1:19.507"
+    q2: "1:18.934"
+    q3: "1:18.518"
+    laps: 22
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    q1: "1:20.120"
+    q2: "1:19.435"
+    q3: "1:18.811"
+    laps: 18
+  - position: 3
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    q1: "1:20.023"
+    q2: "1:19.653"
+    q3: "1:19.303"
+    laps: 19
+  - position: 4
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    q1: "1:20.226"
+    q2: "1:19.357"
+    q3: "1:19.327"
+    laps: 24
+  - position: 5
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    q1: "1:19.664"
+    q2: "1:19.525"
+    q3: "1:19.380"
+    laps: 26
+  - position: 6
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    q1: "1:20.010"
+    q2: "1:19.882"
+    q3: "1:19.475"
+    laps: 26
+  - position: 7
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    q1: "1:19.811"
+    q2: "1:19.921"
+    q3: "1:19.478"
+    laps: 25
+  - position: 8
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    q1: "1:20.491"
+    q2: "1:20.144"
+    q3: "1:19.994"
+    laps: 24
+  - position: 9
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    q1: "1:20.409"
+    q2: "1:19.971"
+    q3: "1:21.247"
+    laps: 25
+  - position: 10
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    q1: "1:20.495"
+    q2: "1:20.221"
+    q3: ""
+    laps: 14
+  - position: 11
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    q1: "1:21.024"
+    q2: "1:20.303"
+    q3: ""
+    laps: 18
+  - position: 12
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    q1: "1:21.247"
+    q2: "1:20.311"
+    q3: ""
+    laps: 18
+  - position: 13
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    q1: "1:20.759"
+    q2: "1:20.491"
+    q3: ""
+    laps: 18
+  - position: 14
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    q1: "1:21.138"
+    q2: "1:20.501"
+    q3: ""
+    laps: 18
+  - position: 15
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    q1: "1:21.051"
+    q2: "1:20.941"
+    q3: ""
+    laps: 19
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    q1: "1:21.200"
+    q2: "1:21.270"
+    q3: ""
+    laps: 18
+  - position: 17
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    q1: "1:21.969"
+    q2: ""
+    q3: ""
+    laps: 10
+  - position: 18
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    q1: "1:22.605"
+    q2: ""
+    q3: ""
+    laps: 7
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    q1: "1:23.244"
+    q2: ""
+    q3: ""
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/01australia/aus01.jpg"
 ---

--- a/src/content/races/2026/austrian-gp.md
+++ b/src/content/races/2026/austrian-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 10
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/11austria/as01.jpg"
 ---

--- a/src/content/races/2026/azerbaijan-gp.md
+++ b/src/content/races/2026/azerbaijan-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 17
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/barcelona-catalunya-gp.md
+++ b/src/content/races/2026/barcelona-catalunya-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 9
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/belgium-gp.md
+++ b/src/content/races/2026/belgium-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 12
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/brazil-gp.md
+++ b/src/content/races/2026/brazil-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 21
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/canadian-gp.md
+++ b/src/content/races/2026/canadian-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 7
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/10canada/ca01.jpg"
 ---

--- a/src/content/races/2026/china-gp.md
+++ b/src/content/races/2026/china-gp.md
@@ -23,6 +23,792 @@ laps: 56
 time: "1:33:15.607"
 hasSprint: true
 raceCompleted: true
+raceResults:
+  - position: 1
+    carNumber: 12
+    driver: "Kimi Anontelli"
+    team: "Mercedes"
+    laps: 56
+    timeOrRetired: "1:33:15.607"
+    points: 25
+  - position: 2
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 56
+    timeOrRetired: "+5.515s"
+    points: 18
+  - position: 3
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 56
+    timeOrRetired: "+25.267s"
+    points: 15
+  - position: 4
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 56
+    timeOrRetired: "+28.894s"
+    points: 12
+  - position: 5
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 56
+    timeOrRetired: "+57.268s"
+    points: 10
+  - position: 6
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 56
+    timeOrRetired: "+59.647s"
+    points: 8
+  - position: 7
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 56
+    timeOrRetired: "+80.588s"
+    points: 6
+  - position: 8
+    carNumber: 30
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 56
+    timeOrRetired: "+87.247s"
+    points: 4
+  - position: 9
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 2
+  - position: 10
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 1
+  - position: 11
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 12
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 13
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 14
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 55
+    timeOrRetired: "+1 laps"
+    points: 0
+  - position: 15
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 55
+    timeOrRetired: "+1 laps"
+    points: 0
+  - position: NC
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 45
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 32
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 9
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+  - position: NC
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+  - position: NC
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+  - position: NC
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 0
+    timeOrRetired: "DNS"
+    points: 0
+practice1Results:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 29
+    timeOrGap: "1:32.741"
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 30
+    timeOrGap: "+0.120s"
+  - position: 3
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 29
+    timeOrGap: "+0.555s"
+  - position: 4
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 28
+    timeOrGap: "+0.731s"
+  - position: 5
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 28
+    timeOrGap: "+0.858s"
+  - position: 6
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 26
+    timeOrGap: "+1.388s"
+  - position: 7
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 28
+    timeOrGap: "+1.685s"
+  - position: 8
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 24
+    timeOrGap: "+1.800s"
+  - position: 9
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 27
+    timeOrGap: "+1.898s"
+  - position: 10
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 28
+    timeOrGap: "+1.935s"
+  - position: 11
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 29
+    timeOrGap: "+2.032s"
+  - position: 12
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 26
+    timeOrGap: "+2.087s"
+  - position: 13
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 26
+    timeOrGap: "+2.115s"
+  - position: 14
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 25
+    timeOrGap: "+2.136s"
+  - position: 15
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 26
+    timeOrGap: "+2.206s"
+  - position: 16
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 31
+    timeOrGap: "+2.739s"
+  - position: 17
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 18
+    timeOrGap: "+2.938s"
+  - position: 18
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 18
+    timeOrGap: "+3.115s"
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 25
+    timeOrGap: "+3.316s"
+  - position: 20
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 20
+    timeOrGap: "+4.483s"
+  - position: 21
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 6
+    timeOrGap: "+5.155s"
+  - position: 22
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 13
+    timeOrGap: "+6.459s"
+practice2Results: []
+practice3Results: []
+qualifyingResults:
+  - position: 1
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    q1: "1:33.305"
+    q2: "1:32.443"
+    q3: "1:32.064"
+    laps: 15
+  - position: 2
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    q1: "1:33.262"
+    q2: "1:32.523"
+    q3: "1:32.286"
+    laps: 13
+  - position: 3
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    q1: "1:33.522"
+    q2: "1:32.567"
+    q3: "1:32.415"
+    laps: 19
+  - position: 4
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    q1: "1:33.175"
+    q2: "1:32.486"
+    q3: "1:32.428"
+    laps: 20
+  - position: 5
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    q1: "1:33.590"
+    q2: "1:33.130"
+    q3: "1:32.550"
+    laps: 20
+  - position: 6
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    q1: "1:33.535"
+    q2: "1:32.910"
+    q3: "1:32.608"
+    laps: 20
+  - position: 7
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    q1: "1:33.788"
+    q2: "1:33.003"
+    q3: "1:32.873"
+    laps: 21
+  - position: 8
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    q1: "1:33.417"
+    q2: "1:33.098"
+    q3: "1:33.002"
+    laps: 20
+  - position: 9
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    q1: "1:33.632"
+    q2: "1:33.352"
+    q3: "1:33.121"
+    laps: 20
+  - position: 10
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    q1: "1:33.687"
+    q2: "1:33.197"
+    q3: "1:33.292"
+    laps: 19
+  - position: 11
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    q1: "1:34.116"
+    q2: "1:33.354"
+    q3: ""
+    laps: 12
+  - position: 12
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    q1: "1:33.634"
+    q2: "1:33.357"
+    q3: ""
+    laps: 15
+  - position: 13
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    q1: "1:33.974"
+    q2: "1:33.538"
+    q3: ""
+    laps: 14
+  - position: 14
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    q1: "1:34.139"
+    q2: "1:33.765"
+    q3: ""
+    laps: 15
+  - position: 15
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    q1: "1:33.906"
+    q2: "1:33.784"
+    q3: ""
+    laps: 15
+  - position: 16
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    q1: "1:33.549"
+    q2: "1:33.965"
+    q3: ""
+    laps: 14
+  - position: 17
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    q1: "1:34.317"
+    q2: ""
+    q3: ""
+    laps: 10
+  - position: 18
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    q1: "1:34.772"
+    q2: ""
+    q3: ""
+    laps: 10
+  - position: 19
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    q1: "1:35.203"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 20
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    q1: "1:35.436"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    q1: "1:35.995"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 22
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    q1: "1:36.906"
+sprintQualifyingResults:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    sq1: "1:33.030"
+    sq2: "1:32.241"
+    sq3: "1:31.520"
+    laps: 13
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    sq1: "1:33.455"
+    sq2: "1:32.291"
+    sq3: "1:31.809"
+    laps: 13
+  - position: 3
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    sq1: "1:33.783"
+    sq2: "1:33.086"
+    sq3: "1:32.141"
+    laps: 13
+  - position: 4
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    sq1: "1:33.148"
+    sq2: "1:33.042"
+    sq3: "1:32.161"
+    laps: 15
+  - position: 5
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    sq1: "1:33.813"
+    sq2: "1:33.038"
+    sq3: "1:32.224"
+    laps: 13
+  - position: 6
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    sq1: "1:33.194"
+    sq2: "1:32.602"
+    sq3: "1:32.528"
+    laps: 16
+  - position: 7
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    sq1: "1:33.970"
+    sq2: "1:33.405"
+    sq3: "1:32.888"
+    laps: 15
+  - position: 8
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    sq1: "1:34.170"
+    sq2: "1:33.564"
+    sq3: "1:33.254"
+    laps: 17
+  - position: 9
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    sq1: "1:34.280"
+    sq2: "1:33.501"
+    sq3: "1:33.409"
+    laps: 16
+  - position: 10
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    sq1: "1:34.447"
+    sq2: "1:33.620"
+    sq3: "1:33.723"
+    laps: 15
+  - position: 11
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    sq1: "1:33.997"
+    sq2: "1:33.635"
+    sq3: ""
+    laps: 14
+  - position: 12
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    sq1: "1:34.087"
+    sq2: "1:33.639"
+    sq3: ""
+    laps: 13
+  - position: 13
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    sq1: "1:34.110"
+    sq2: "1:33.714"
+    sq3: ""
+    laps: 13
+  - position: 14
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    sq1: "1:34.291"
+    sq2: "1:33.774"
+    sq3: ""
+    laps: 14
+  - position: 15
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    sq1: "1:34.495"
+    sq2: "1:34.048"
+    sq3: ""
+    laps: 13
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    sq1: "1:34.592"
+    sq2: "1:34.327"
+    sq3: ""
+    laps: 12
+  - position: 17
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    sq1: "1:34.761"
+    sq2: ""
+    sq3: ""
+    laps: 6
+  - position: 18
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    sq1: "1:35.305"
+    sq2: ""
+    sq3: ""
+    laps: 6
+  - position: 19
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    sq1: "1:35.581"
+    sq2: ""
+    sq3: ""
+    laps: 5
+  - position: 20
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    sq1: "1:36.151"
+    sq2: ""
+    sq3: ""
+    laps: 7
+  - position: 21
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    sq1: "1:37.378"
+sprintResults:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 19
+    timeOrRetired: "33:38.998"
+    points: 8
+  - position: 2
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 19
+    timeOrRetired: "+0.674s"
+    points: 7
+  - position: 3
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 19
+    timeOrRetired: "+2.554s"
+    points: 6
+  - position: 4
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 19
+    timeOrRetired: "+4.433s"
+    points: 5
+  - position: 5
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 19
+    timeOrRetired: "+5.688s"
+    points: 4
+  - position: 6
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 19
+    timeOrRetired: "+6.809s"
+    points: 3
+  - position: 7
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 19
+    timeOrRetired: "+10.900s"
+    points: 2
+  - position: 8
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 19
+    timeOrRetired: "+11.271s"
+    points: 1
+  - position: 9
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 19
+    timeOrRetired: "+11.619s"
+    points: 0
+  - position: 10
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 19
+    timeOrRetired: "+13.887s"
+    points: 0
+  - position: 11
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 19
+    timeOrRetired: "+14.780s"
+    points: 0
+  - position: 12
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 19
+    timeOrRetired: "+15.753s"
+    points: 0
+  - position: 13
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 19
+    timeOrRetired: "+15.858s"
+    points: 0
+  - position: 14
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 19
+    timeOrRetired: "+16.393s"
+    points: 0
+  - position: 15
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 19
+    timeOrRetired: "+16.430s"
+    points: 0
+  - position: 16
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 19
+    timeOrRetired: "+20.014s"
+    points: 0
+  - position: 17
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 19
+    timeOrRetired: "+21.599s"
+    points: 0
+  - position: 18
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 19
+    timeOrRetired: "+21.971s"
+    points: 0
+  - position: 19
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 19
+    timeOrRetired: "+28.241s"
+    points: 0
+  - position: NC
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 12
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 12
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 11
+    timeOrRetired: "DNF"
+    points: 0
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/02china/cn01.jpg"
 ---

--- a/src/content/races/2026/great-britain-gp.md
+++ b/src/content/races/2026/great-britain-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 11
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/12great-britain/gb01.jpg"
 ---

--- a/src/content/races/2026/hungary-gp.md
+++ b/src/content/races/2026/hungary-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 13
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/italy-gp.md
+++ b/src/content/races/2026/italy-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 15
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/japan-gp.md
+++ b/src/content/races/2026/japan-gp.md
@@ -22,6 +22,738 @@ raceNumber: 3
 laps: 53
 time: "1:28:03.403"
 raceCompleted: true
+raceResults:
+  - position: 1
+    carNumber: 12
+    driver: "Kimi Anontelli"
+    team: "Mercedes"
+    laps: 53
+    timeOrRetired: "1:28.03.403"
+    points: 25
+  - position: 2
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 53
+    timeOrRetired: "+13.722s"
+    points: 18
+  - position: 3
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 53
+    timeOrRetired: "+15.270s"
+    points: 15
+  - position: 4
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 53
+    timeOrRetired: "+15.754s"
+    points: 12
+  - position: 5
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 53
+    timeOrRetired: "+57.268s"
+    points: 10
+  - position: 6
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 53
+    timeOrRetired: "+25.037s"
+    points: 8
+  - position: 7
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 53
+    timeOrRetired: "+32.340s"
+    points: 6
+  - position: 8
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 53
+    timeOrRetired: "+32.677s"
+    points: 4
+  - position: 9
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 53
+    timeOrRetired: "+50.180s"
+    points: 2
+  - position: 10
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 53
+    timeOrRetired: "+51.216s"
+    points: 1
+  - position: 11
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 55
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 12
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Racing Bulls"
+    laps: 53
+    timeOrRetired: "+56.154s"
+    points: 0
+  - position: 13
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Cadillac"
+    laps: 53
+    timeOrRetired: "+59.078s"
+    points: 0
+  - position: 14
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 53
+    timeOrRetired: "+59.848s"
+    points: 0
+  - position: 15
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 53
+    timeOrRetired: "+65.008s"
+    points: 0
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 53
+    timeOrRetired: "+65.773s"
+    points: 0
+  - position: 17
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 53
+    timeOrRetired: "+92.453s"
+    points: 0
+  - position: 18
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 52
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 52
+    timeOrRetired: "+1 lap"
+    points: 0
+  - position: 20
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 51
+    timeOrRetired: "+2 laps"
+    points: 0
+  - position: NC
+    carNumber: 5
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 30
+    timeOrRetired: "DNF"
+    points: 0
+  - position: NC
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 20
+    timeOrRetired: "DNF"
+    points: 0
+practice1Results:
+  - position: 1
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 27
+    timeOrGap: "1:31.666"
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 26
+    timeOrGap: "+0.026s"
+  - position: 3
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 20
+    timeOrGap: "+0.132s"
+  - position: 4
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 23
+    timeOrGap: "+0.199s"
+  - position: 5
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 25
+    timeOrGap: "+0.289s"
+  - position: 6
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 23
+    timeOrGap: "+0.374s"
+  - position: 7
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 27
+    timeOrGap: "+0.791s"
+  - position: 8
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 27
+    timeOrGap: "+0.863s"
+  - position: 9
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 23
+    timeOrGap: "+0.935s"
+  - position: 10
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 29
+    timeOrGap: "+0.999s"
+  - position: 11
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 27
+    timeOrGap: "+1.093s"
+  - position: 12
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 26
+    timeOrGap: "+1.132s"
+  - position: 13
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 27
+    timeOrGap: "+1.137s"
+  - position: 14
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 27
+    timeOrGap: "+1.234s"
+  - position: 15
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 25
+    timeOrGap: "+1.312s"
+  - position: 16
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 24
+    timeOrGap: "+1.695s"
+  - position: 17
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 26
+    timeOrGap: "+1.717s"
+  - position: 18
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 22
+    timeOrGap: "+2.031s"
+  - position: 19
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 18
+    timeOrGap: "+2.555s"
+  - position: 20
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 24
+    timeOrGap: "+2.824s"
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 22
+    timeOrGap: "+3.628s"
+  - position: 22
+    carNumber: 34
+    driver: "Jak Crawford"
+    team: "Aston Martin"
+    laps: 11
+    timeOrGap: "+4.696s"
+practice2Results:
+  - position: 1
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 29
+    timeOrGap: "1:30.133"
+  - position: 2
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 28
+    timeOrGap: "+0.092s"
+  - position: 3
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 29
+    timeOrGap: "+0.205s"
+  - position: 4
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 17
+    timeOrGap: "+0.516s"
+  - position: 5
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 28
+    timeOrGap: "+0.713s"
+  - position: 6
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 27
+    timeOrGap: "+0.847s"
+  - position: 7
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 27
+    timeOrGap: "+1.308s"
+  - position: 8
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 30
+    timeOrGap: "+1.363s"
+  - position: 9
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 28
+    timeOrGap: "+1.365s"
+  - position: 10
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 29
+    timeOrGap: "+1.376s"
+  - position: 11
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 30
+    timeOrGap: "+1.399s"
+  - position: 12
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 31
+    timeOrGap: "+1.457s"
+  - position: 13
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 30
+    timeOrGap: "+1.475s"
+  - position: 14
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 29
+    timeOrGap: "+1.601s"
+  - position: 15
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 29
+    timeOrGap: "+1.626s"
+  - position: 16
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 11
+    timeOrGap: "+1.800s"
+  - position: 17
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 28
+    timeOrGap: "+2.305s"
+  - position: 18
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 28
+    timeOrGap: "+2.482s"
+  - position: 19
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 24
+    timeOrGap: "+3.463s"
+  - position: 20
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 14
+    timeOrGap: "+3.556s"
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 21
+    timeOrGap: "+3.818s"
+  - position: 22
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 1
+    timeOrGap: ""
+practice3Results:
+  - position: 1
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    laps: 18
+    timeOrGap: "1:29.362"
+  - position: 2
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    laps: 18
+    timeOrGap: "+0.254s"
+  - position: 3
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    laps: 20
+    timeOrGap: "+0.867s"
+  - position: 4
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    laps: 19
+    timeOrGap: "+1.002s"
+  - position: 5
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    laps: 23
+    timeOrGap: "+1.021s"
+  - position: 6
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    laps: 13
+    timeOrGap: "+1.238s"
+  - position: 7
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    laps: 21
+    timeOrGap: "+1.296s"
+  - position: 8
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    laps: 22
+    timeOrGap: "+1.548s"
+  - position: 9
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    laps: 21
+    timeOrGap: "+1.638s"
+  - position: 10
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    laps: 20
+    timeOrGap: "+1.720s"
+  - position: 11
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    laps: 21
+    timeOrGap: "+1.732s"
+  - position: 12
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    laps: 21
+    timeOrGap: "+1.735s"
+  - position: 13
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    laps: 17
+    timeOrGap: "+1.926s"
+  - position: 14
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    laps: 22
+    timeOrGap: "+1.964s"
+  - position: 15
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    laps: 18
+    timeOrGap: "+2.196s"
+  - position: 16
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    laps: 20
+    timeOrGap: "+2.371s"
+  - position: 17
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    laps: 25
+    timeOrGap: "+2.397s"
+  - position: 18
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    laps: 26
+    timeOrGap: "+2.467s"
+  - position: 19
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    laps: 20
+    timeOrGap: "+3.141s"
+  - position: 20
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    laps: 18
+    timeOrGap: "+3.178s"
+  - position: 21
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    laps: 19
+    timeOrGap: "+4.123s"
+  - position: 22
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    laps: 14
+    timeOrGap: "+4.167s"
+qualifyingResults:
+  - position: 1
+    carNumber: 12
+    driver: "Kimi Antonelli"
+    team: "Mercedes"
+    q1: "1:30.035"
+    q2: "1:29.048"
+    q3: "1:28.778"
+    laps: 15
+  - position: 2
+    carNumber: 63
+    driver: "George Russell"
+    team: "Mercedes"
+    q1: "1:29.967"
+    q2: "1:29.686"
+    q3: "1:29.076"
+    laps: 21
+  - position: 3
+    carNumber: 81
+    driver: "Oscar Piastri"
+    team: "McLaren"
+    q1: "1:30.200"
+    q2: "1:29.451"
+    q3: "1:29.132"
+    laps: 20
+  - position: 4
+    carNumber: 16
+    driver: "Charles Leclerc"
+    team: "Ferrari"
+    q1: "1:29.915"
+    q2: "1:29.303"
+    q3: "1:29.405"
+    laps: 18
+  - position: 5
+    carNumber: 1
+    driver: "Lando Norris"
+    team: "McLaren"
+    q1: "1:30.401"
+    q2: "1:29.795"
+    q3: "1:29.409"
+    laps: 20
+  - position: 6
+    carNumber: 44
+    driver: "Lewis Hamilton"
+    team: "Ferrari"
+    q1: "1:30.309"
+    q2: "1:29.589"
+    q3: "1:29.567"
+    laps: 20
+  - position: 7
+    carNumber: 10
+    driver: "Pierre Gasly"
+    team: "Alpine"
+    q1: "1:30.584"
+    q2: "1:29.874"
+    q3: "1:29.691"
+    laps: 18
+  - position: 8
+    carNumber: 6
+    driver: "Isack Hadjar"
+    team: "Red Bull Racing"
+    q1: "1:30.662"
+    q2: "1:30.104"
+    q3: "1:29.978"
+    laps: 17
+  - position: 9
+    carNumber: 5
+    driver: "Gabriel Bortoleto"
+    team: "Audi"
+    q1: "1:30.359"
+    q2: "1:29.990"
+    q3: "1:30.274"
+    laps: 20
+  - position: 10
+    carNumber: 41
+    driver: "Arvid Lindblad"
+    team: "Racing Bulls"
+    q1: "1:30.781"
+    q2: "1:30.109"
+    q3: "1:30.319"
+    laps: 21
+  - position: 11
+    carNumber: 3
+    driver: "Max Verstappen"
+    team: "Red Bull Racing"
+    q1: "1:30.519"
+    q2: "1:30.262"
+    q3: ""
+    laps: 12
+  - position: 12
+    carNumber: 31
+    driver: "Esteban Ocon"
+    team: "Haas"
+    q1: "1:30.915"
+    q2: "1:30.309"
+    q3: ""
+    laps: 15
+  - position: 13
+    carNumber: 27
+    driver: "Nico Hulkenberg"
+    team: "Audi"
+    q1: "1:30.358"
+    q2: "1:30.387"
+    q3: ""
+    laps: 14
+  - position: 14
+    carNumber: 30
+    driver: "Liam Lawson"
+    team: "Racing Bulls"
+    q1: "1:30.657"
+    q2: "1:30.495"
+    q3: ""
+    laps: 15
+  - position: 15
+    carNumber: 43
+    driver: "Franco Colapinto"
+    team: "Alpine"
+    q1: "1:30.931"
+    q2: "1:30.627"
+    q3: ""
+    laps: 12
+  - position: 16
+    carNumber: 55
+    driver: "Carlos Sainz"
+    team: "Williams"
+    q1: "1:30.927"
+    q2: "1:31.033"
+    q3: ""
+    laps: 15
+  - position: 17
+    carNumber: 23
+    driver: "Alexander Albon"
+    team: "Williams"
+    q1: "1:31.088"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 18
+    carNumber: 87
+    driver: "Oliver Bearman"
+    team: "Haas"
+    q1: "1:31.090"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 19
+    carNumber: 11
+    driver: "Sergio Perez"
+    team: "Cadillac"
+    q1: "1:32.206"
+    q2: ""
+    q3: ""
+    laps: 6
+  - position: 20
+    carNumber: 77
+    driver: "Valtteri Bottas"
+    team: "Cadillac"
+    q1: "1:32.330"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 21
+    carNumber: 14
+    driver: "Fernando Alonso"
+    team: "Aston Martin"
+    q1: "1:32.646"
+    q2: ""
+    q3: ""
+    laps: 9
+  - position: 22
+    carNumber: 18
+    driver: "Lance Stroll"
+    team: "Aston Martin"
+    q1: "1:32.920"
+    q2: ""
+    q3: ""
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/03japan/jp05.jpg"
 ---

--- a/src/content/races/2026/las-vegas-gp.md
+++ b/src/content/races/2026/las-vegas-gp.md
@@ -2,7 +2,7 @@
 raceName: "Formula 1 Heineken Las Vegas Grand Prix 2026"
 trackName: "Las Vegas Strip Circuit"
 trackLocation: "Paradise, Nevada"
-trackCountry: "United States"
+trackCountry: "Las Vegas"
 trackImage: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageLarge: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageAlt: "Las Vegas Strip Circuit"
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 22
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/mexico-gp.md
+++ b/src/content/races/2026/mexico-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 20
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/miami-gp.md
+++ b/src/content/races/2026/miami-gp.md
@@ -2,7 +2,7 @@
 raceName: "Formula 1 Crypto.com Miami Grand Prix 2026"
 trackName: "Miami International Autodrome"
 trackLocation: "Miami Gardens, Florida"
-trackCountry: "United States"
+trackCountry: "Miami"
 trackImage: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageLarge: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageAlt: "Miami International Autodrome"
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 6
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/monaco-gp.md
+++ b/src/content/races/2026/monaco-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 8
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/netherlands-gp.md
+++ b/src/content/races/2026/netherlands-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 14
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/qatar-gp.md
+++ b/src/content/races/2026/qatar-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 23
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/singapore-gp.md
+++ b/src/content/races/2026/singapore-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 18
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/spain-gp.md
+++ b/src/content/races/2026/spain-gp.md
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 16
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/content/races/2026/testing-sakhir-1.md
+++ b/src/content/races/2026/testing-sakhir-1.md
@@ -19,7 +19,7 @@ fastestLapDriver: ""
 fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 0
-raceCompleted: false
+raceCompleted: true
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/04bahrain/bh01.jpg"
 ---

--- a/src/content/races/2026/testing-sakhir-2.md
+++ b/src/content/races/2026/testing-sakhir-2.md
@@ -19,7 +19,7 @@ fastestLapDriver: ""
 fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 0
-raceCompleted: false
+raceCompleted: true
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/04bahrain/bh01.jpg"
 ---

--- a/src/content/races/2026/united-states-gp.md
+++ b/src/content/races/2026/united-states-gp.md
@@ -2,7 +2,7 @@
 raceName: "Formula 1 MSC Cruises United States Grand Prix 2026"
 trackName: "Circuit of The Americas"
 trackLocation: "Austin, Texas"
-trackCountry: "United States"
+trackCountry: "Texas"
 trackImage: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageLarge: "../../../assets/circuits/06miami/mi01.jpg"
 trackImageAlt: "Circuit of The Americas"
@@ -20,6 +20,13 @@ fastestLapConstructor: ""
 fastestLapTime: ""
 raceNumber: 19
 raceCompleted: false
+raceResults: []
+practice1Results: []
+practice2Results: []
+practice3Results: []
+qualifyingResults: []
+sprintResults: []
+fastestLapResults: []
 pubDate: "January 02, 2026"
 heroImage: "../../../assets/circuits/06miami/mi01.jpg"
 ---

--- a/src/pages/results/[season]/races/[raceSlug].astro
+++ b/src/pages/results/[season]/races/[raceSlug].astro
@@ -16,6 +16,7 @@ const SESSION_OPTIONS = [
   { id: "practice-1", label: "Practice 1" },
   { id: "practice-2", label: "Practice 2" },
   { id: "practice-3", label: "Practice 3" },
+  { id: "sprint-qualifying", label: "Sprint Qualifying" },
   { id: "qualifying", label: "Qualifying" },
   { id: "sprint", label: "Sprint" },
   { id: "fastest-laps", label: "Fastest Laps" },
@@ -76,16 +77,36 @@ const constructorSlugByName = new Map(
   ]),
 );
 
+const teamColorMap: Record<string, string> = {
+  McLaren: "#FF8000",
+  Ferrari: "#E8002D",
+  Mercedes: "#27F4D2",
+  Williams: "#64C4FF",
+  "Red Bull Racing": "#3671C6",
+  "Kick Sauber": "#52E252",
+  "Racing Bulls": "#6692FF",
+  "Aston Martin": "#229971",
+  Haas: "#B6BABD",
+  Alpine: "#FF87BC",
+  Cadillac: "#CC0000",
+  Audi: "#BB0000",
+};
+
 const activeSession: SessionId = "race";
-const visibleSessions = SESSION_OPTIONS.filter(
-  (s) => s.id !== "sprint" || race.data.hasSprint,
-);
+const visibleSessions = SESSION_OPTIONS.filter((s) => {
+  if (race.data.hasSprint) {
+    return s.id !== "practice-2" && s.id !== "practice-3";
+  }
+
+  return s.id !== "sprint" && s.id !== "sprint-qualifying";
+});
 
 const sessionRowsMap: Record<SessionId, ResultRow[]> = {
   race: race.data.raceResults ?? [],
   "practice-1": race.data.practice1Results ?? [],
   "practice-2": race.data.practice2Results ?? [],
   "practice-3": race.data.practice3Results ?? [],
+  "sprint-qualifying": race.data.sprintQualifyingResults ?? [],
   qualifying: race.data.qualifyingResults ?? [],
   sprint: race.data.sprintResults ?? [],
   "fastest-laps": race.data.fastestLapResults ?? [],
@@ -155,14 +176,14 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
       />
 
       <section class="container mx-auto mb-12 mt-8 px-4">
-        <div class="overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 px-5 py-6 text-zinc-100 sm:px-8 sm:py-7">
+        <div class="overflow-hidden rounded-2xl border border-zinc-200 bg-white px-5 py-6 text-zinc-900 sm:px-8 sm:py-7 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100">
           <div class="mb-6 flex flex-wrap items-center gap-3">
             <div class="w-full sm:w-auto">
               <label for="race-select" class="sr-only">Select race</label>
               <div class="relative">
               <select
                 id="race-select"
-                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-300 bg-white px-4 py-2 pr-10 text-sm font-semibold text-zinc-900 shadow-sm sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
               >
                 {
                   seasonRaces.map((raceOption: RaceEntry) => {
@@ -178,7 +199,7 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                   })
                 }
               </select>
-              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-900 dark:text-white">
                 <Icon name="mdi:chevron-down" size={18} />
               </span>
               </div>
@@ -189,7 +210,7 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
               <div class="relative">
               <select
                 id="session-select"
-                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                class="w-full cursor-pointer appearance-none rounded-full border border-zinc-300 bg-white px-4 py-2 pr-10 text-sm font-semibold text-zinc-900 shadow-sm sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
               >
                 {
                   visibleSessions.map((option) => (
@@ -206,13 +227,13 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                   ))
                 }
               </select>
-              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+              <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-900 dark:text-white">
                 <Icon name="mdi:chevron-down" size={18} />
               </span>
               </div>
             </div>
 
-            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-600 p-2 sm:flex">
+            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-300 bg-zinc-50 p-2 sm:flex dark:border-zinc-600 dark:bg-zinc-900">
               <span class={`fi fi-${flagCode} rounded-sm`} />
             </div>
           </div>
@@ -221,16 +242,16 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
             {race.data.raceName} - {activeLabel}
           </h1>
 
-          <p class="mt-5 text-sm font-bold uppercase text-zinc-300 sm:text-base">
+          <p class="mt-5 text-sm font-bold uppercase text-zinc-600 sm:text-base dark:text-zinc-300">
             {dateLabel}
           </p>
-          <p class="text-zinc-300">
+          <p class="text-zinc-600 dark:text-zinc-300">
             {race.data.trackName}, {race.data.trackLocation}
           </p>
 
-          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-800 bg-black">
+          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-black">
             <table class="w-full text-sm">
-              <thead class="border-b border-zinc-800">
+              <thead class="border-b border-zinc-200 dark:border-zinc-800">
                 <tr>
                   {[
                     "Pos.",
@@ -241,7 +262,7 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                     "Time / Retired",
                     "Pts.",
                   ].map((heading) => (
-                    <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-300">
+                    <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-300">
                       {heading}
                     </th>
                   ))}
@@ -258,18 +279,18 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                         normalizeName(row.team),
                       );
                       return (
-                        <tr class="border-b border-zinc-900 last:border-b-0">
-                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                        <tr class="border-b border-zinc-200 last:border-b-0 dark:border-zinc-900">
+                          <td class="px-4 py-4 text-base text-zinc-900 dark:text-zinc-100">
                             {row.position}
                           </td>
-                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                          <td class="px-4 py-4 text-base text-zinc-900 dark:text-zinc-100">
                             {row.carNumber ?? "-"}
                           </td>
-                          <td class="px-4 py-4 font-semibold text-zinc-100">
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
                             {driverSlug ? (
                               <a
                                 href={`/seasons/${season}/drivers/${driverSlug}`}
-                                class="hover:text-rose-400"
+                                class="hover:text-rose-600 dark:hover:text-rose-400"
                               >
                                 {row.driver}
                               </a>
@@ -277,29 +298,41 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                               row.driver
                             )}
                           </td>
-                          <td class="px-4 py-4 text-zinc-100">
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
                             {teamSlug ? (
                               <a
                                 href={`/seasons/${season}/constructors/${teamSlug}`}
-                                class="hover:text-rose-400"
+                                class="inline-flex items-center gap-2 hover:text-rose-600 dark:hover:text-rose-400"
                               >
+                                <span
+                                  class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={`background-color: ${teamColorMap[row.team] ?? "#71717a"}`}
+                                  aria-hidden="true"
+                                />
                                 {row.team}
                               </a>
                             ) : (
-                              row.team
+                              <span class="inline-flex items-center gap-2">
+                                <span
+                                  class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={`background-color: ${teamColorMap[row.team] ?? "#71717a"}`}
+                                  aria-hidden="true"
+                                />
+                                {row.team}
+                              </span>
                             )}
                           </td>
-                          <td class="px-4 py-4 text-zinc-100">{row.laps ?? "-"}</td>
-                          <td class="px-4 py-4 font-mono text-zinc-100">
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">{row.laps ?? "-"}</td>
+                          <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
                             {row.timeOrRetired ?? "-"}
                           </td>
-                          <td class="px-4 py-4 text-zinc-100">{row.points ?? "-"}</td>
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">{row.points ?? "-"}</td>
                         </tr>
                       );
                     })
                   ) : (
                     <tr>
-                      <td colspan={7} class="px-4 py-10 text-center text-zinc-400">
+                      <td colspan={7} class="px-4 py-10 text-center text-zinc-500 dark:text-zinc-400">
                         {activeLabel} data is not available yet for this Grand Prix.
                       </td>
                     </tr>

--- a/src/pages/results/[season]/races/[raceSlug]/[session].astro
+++ b/src/pages/results/[season]/races/[raceSlug]/[session].astro
@@ -16,6 +16,7 @@ const SESSION_OPTIONS = [
   { id: "practice-1", label: "Practice 1" },
   { id: "practice-2", label: "Practice 2" },
   { id: "practice-3", label: "Practice 3" },
+  { id: "sprint-qualifying", label: "Sprint Qualifying" },
   { id: "qualifying", label: "Qualifying" },
   { id: "sprint", label: "Sprint" },
   { id: "fastest-laps", label: "Fastest Laps" },
@@ -25,7 +26,22 @@ type SessionId = (typeof SESSION_OPTIONS)[number]["id"];
 type RaceEntry = CollectionEntry<"races">;
 type DriverEntry = CollectionEntry<"drivers">;
 type ConstructorEntry = CollectionEntry<"constructors">;
-type ResultRow = NonNullable<RaceEntry["data"]["raceResults"]>[number];
+type ResultRow = {
+  position: number | "NC" | "DNS" | "DSQ" | "DNQ" | "DNF";
+  carNumber?: number;
+  driver: string;
+  team: string;
+  laps?: number;
+  timeOrRetired?: string;
+  timeOrGap?: string;
+  q1?: string;
+  q2?: string;
+  q3?: string;
+  sq1?: string;
+  sq2?: string;
+  sq3?: string;
+  points?: number;
+};
 
 export async function getStaticPaths() {
   const SESSION_IDS = [
@@ -33,6 +49,7 @@ export async function getStaticPaths() {
     "practice-1",
     "practice-2",
     "practice-3",
+    "sprint-qualifying",
     "qualifying",
     "sprint",
     "fastest-laps",
@@ -96,20 +113,41 @@ const constructorSlugByName = new Map(
   ]),
 );
 
+const teamColorMap: Record<string, string> = {
+  McLaren: "#FF8000",
+  Ferrari: "#E8002D",
+  Mercedes: "#27F4D2",
+  Williams: "#64C4FF",
+  "Red Bull Racing": "#3671C6",
+  "Kick Sauber": "#52E252",
+  "Racing Bulls": "#6692FF",
+  "Aston Martin": "#229971",
+  Haas: "#B6BABD",
+  Alpine: "#FF87BC",
+  Cadillac: "#CC0000",
+  Audi: "#BB0000",
+};
+
 const sessionRowsMap: Record<SessionId, ResultRow[]> = {
   race: race.data.raceResults ?? [],
   "practice-1": race.data.practice1Results ?? [],
   "practice-2": race.data.practice2Results ?? [],
   "practice-3": race.data.practice3Results ?? [],
+  "sprint-qualifying": race.data.sprintQualifyingResults ?? [],
   qualifying: race.data.qualifyingResults ?? [],
   sprint: race.data.sprintResults ?? [],
   "fastest-laps": race.data.fastestLapResults ?? [],
 };
 
 const activeRows = sessionRowsMap[activeSession];
-const visibleSessions = SESSION_OPTIONS.filter(
-  (s) => s.id !== "sprint" || race.data.hasSprint,
-);
+const visibleSessions = SESSION_OPTIONS.filter((s) => {
+  if (race.data.hasSprint) {
+    // Sprint weekends: one practice session plus sprint qualifying and sprint.
+    return s.id !== "practice-2" && s.id !== "practice-3";
+  }
+
+  return s.id !== "sprint" && s.id !== "sprint-qualifying";
+});
 const activeLabel =
   SESSION_OPTIONS.find((option) => option.id === activeSession)?.label ??
   "Race Result";
@@ -173,14 +211,14 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
       />
 
       <section class="container mx-auto mb-12 mt-8 px-4">
-        <div class="overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 px-5 py-6 text-zinc-100 sm:px-8 sm:py-7">
+        <div class="overflow-hidden rounded-2xl border border-zinc-200 bg-white px-5 py-6 text-zinc-900 sm:px-8 sm:py-7 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100">
           <div class="mb-6 flex flex-wrap items-center gap-3">
             <div class="w-full sm:w-auto">
               <label for="race-select" class="sr-only">Select race</label>
               <div class="relative">
                 <select
                   id="race-select"
-                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-300 bg-white px-4 py-2 pr-10 text-sm font-semibold text-zinc-900 shadow-sm sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
                 >
                   {
                     seasonRaces.map((raceOption: RaceEntry) => {
@@ -200,7 +238,7 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                     })
                   }
                 </select>
-                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-900 dark:text-white">
                   <Icon name="mdi:chevron-down" size={18} />
                 </span>
               </div>
@@ -211,7 +249,7 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
               <div class="relative">
                 <select
                   id="session-select"
-                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-200 bg-zinc-900 px-4 py-2 pr-10 text-sm font-semibold text-zinc-100 sm:w-auto"
+                  class="w-full cursor-pointer appearance-none rounded-full border border-zinc-300 bg-white px-4 py-2 pr-10 text-sm font-semibold text-zinc-900 shadow-sm sm:w-auto dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
                 >
                   {
                     visibleSessions.map((option) => (
@@ -228,13 +266,13 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                     ))
                   }
                 </select>
-                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white">
+                <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-zinc-900 dark:text-white">
                   <Icon name="mdi:chevron-down" size={18} />
                 </span>
               </div>
             </div>
 
-            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-600 p-2 sm:flex">
+            <div class="ml-auto hidden items-center justify-center rounded-full border border-zinc-300 bg-zinc-50 p-2 sm:flex dark:border-zinc-600 dark:bg-zinc-900">
               <span class={`fi fi-${flagCode} rounded-sm`} />
             </div>
           </div>
@@ -243,30 +281,51 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
             {race.data.raceName} - {activeLabel}
           </h1>
 
-          <p class="mt-5 text-sm font-bold uppercase text-zinc-300 sm:text-base">
+          <p class="mt-5 text-sm font-bold uppercase text-zinc-600 sm:text-base dark:text-zinc-300">
             {dateLabel}
           </p>
-          <p class="text-zinc-300">
+          <p class="text-zinc-600 dark:text-zinc-300">
             {race.data.trackName}, {race.data.trackLocation}
           </p>
 
-          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-800 bg-black">
+          <div class="mt-7 overflow-hidden rounded-xl border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-black">
             <table class="w-full text-sm">
-              <thead class="border-b border-zinc-800">
+              <thead class="border-b border-zinc-200 dark:border-zinc-800">
                 <tr>
-                  {[
-                    "Pos.",
-                    "No.",
-                    "Driver",
-                    "Team",
-                    "Laps",
-                    "Time / Retired",
-                    "Pts.",
-                  ].map((heading) => (
-                    <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-300">
-                      {heading}
-                    </th>
-                  ))}
+                  {(() => {
+                    const isPractice = ["practice-1", "practice-2", "practice-3"].includes(
+                      activeSession,
+                    );
+                    const isSprintQualifying = activeSession === "sprint-qualifying";
+                    const isQualifying = activeSession === "qualifying";
+                    const headings = isPractice
+                      ? [
+                          "Pos.",
+                          "No.",
+                          "Driver",
+                          "Team",
+                          "Time / Gap",
+                          "Laps",
+                        ]
+                      : isSprintQualifying
+                        ? ["Pos.", "No.", "Driver", "Team", "SQ1", "SQ2", "SQ3"]
+                      : isQualifying
+                        ? ["Pos.", "No.", "Driver", "Team", "Q1", "Q2", "Q3"]
+                      : [
+                          "Pos.",
+                          "No.",
+                          "Driver",
+                          "Team",
+                          "Laps",
+                          "Time / Retired",
+                          "Pts.",
+                        ];
+                    return headings.map((heading) => (
+                      <th class="px-4 py-4 text-left text-xs font-semibold uppercase tracking-widest text-zinc-600 dark:text-zinc-300">
+                        {heading}
+                      </th>
+                    ));
+                  })()}
                 </tr>
               </thead>
               <tbody>
@@ -279,19 +338,24 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                       const teamSlug = constructorSlugByName.get(
                         normalizeName(row.team),
                       );
+                      const isPractice = ["practice-1", "practice-2", "practice-3"].includes(
+                        activeSession,
+                      );
+                      const isSprintQualifying = activeSession === "sprint-qualifying";
+                      const isQualifying = activeSession === "qualifying";
                       return (
-                        <tr class="border-b border-zinc-900 last:border-b-0">
-                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                        <tr class="border-b border-zinc-200 last:border-b-0 dark:border-zinc-900">
+                          <td class="px-4 py-4 text-base text-zinc-900 dark:text-zinc-100">
                             {row.position}
                           </td>
-                          <td class="px-4 py-4 text-base font-black text-zinc-100">
+                          <td class="px-4 py-4 text-base text-zinc-900 dark:text-zinc-100">
                             {row.carNumber ?? "-"}
                           </td>
-                          <td class="px-4 py-4 font-semibold text-zinc-100">
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
                             {driverSlug ? (
                               <a
                                 href={`/seasons/${season}/drivers/${driverSlug}`}
-                                class="hover:text-rose-400"
+                                class="hover:text-rose-600 dark:hover:text-rose-400"
                               >
                                 {row.driver}
                               </a>
@@ -299,29 +363,82 @@ const flagCode = countryFlagMap[race.data.trackCountry] ?? "un";
                               row.driver
                             )}
                           </td>
-                          <td class="px-4 py-4 text-zinc-100">
+                          <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
                             {teamSlug ? (
                               <a
                                 href={`/seasons/${season}/constructors/${teamSlug}`}
-                                class="hover:text-rose-400"
+                                class="inline-flex items-center gap-2 hover:text-rose-600 dark:hover:text-rose-400"
                               >
+                                <span
+                                  class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={`background-color: ${teamColorMap[row.team] ?? "#71717a"}`}
+                                  aria-hidden="true"
+                                />
                                 {row.team}
                               </a>
                             ) : (
-                              row.team
+                              <span class="inline-flex items-center gap-2">
+                                <span
+                                  class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                                  style={`background-color: ${teamColorMap[row.team] ?? "#71717a"}`}
+                                  aria-hidden="true"
+                                />
+                                {row.team}
+                              </span>
                             )}
                           </td>
-                          <td class="px-4 py-4 text-zinc-100">{row.laps ?? "-"}</td>
-                          <td class="px-4 py-4 font-mono text-zinc-100">
-                            {row.timeOrRetired ?? "-"}
-                          </td>
-                          <td class="px-4 py-4 text-zinc-100">{row.points ?? "-"}</td>
+                          {isPractice ? (
+                            <>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.timeOrGap ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
+                                {row.laps ?? "-"}
+                              </td>
+                            </>
+                          ) : isSprintQualifying ? (
+                            <>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.sq1 ?? row.q1 ?? row.timeOrGap ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.sq2 ?? row.q2 ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.sq3 ?? row.q3 ?? "-"}
+                              </td>
+                            </>
+                          ) : isQualifying ? (
+                            <>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.q1 ?? row.timeOrGap ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.q2 ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.q3 ?? "-"}
+                              </td>
+                            </>
+                          ) : (
+                            <>
+                              <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
+                                {row.laps ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 font-mono text-zinc-900 dark:text-zinc-100">
+                                {row.timeOrRetired ?? "-"}
+                              </td>
+                              <td class="px-4 py-4 text-zinc-900 dark:text-zinc-100">
+                                {row.points ?? "-"}
+                              </td>
+                            </>
+                          )}
                         </tr>
                       );
                     })
                   ) : (
                     <tr>
-                      <td colspan={7} class="px-4 py-10 text-center text-zinc-400">
+                      <td colspan={7} class="px-4 py-10 text-center text-zinc-500 dark:text-zinc-400">
                         {activeLabel} data is not available yet for this Grand Prix.
                       </td>
                     </tr>

--- a/src/pages/results/index.astro
+++ b/src/pages/results/index.astro
@@ -208,7 +208,7 @@ const countryFlagMap: Record<string, string> = {
                           <td class="px-4 py-3">
                             <a
                               href={`/results/${season}/races/${raceSlug}`}
-                              class="inline-flex items-center gap-2 font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                              class="inline-flex items-center gap-2 text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
                             >
                               <span
                                 class={`fi fi-${flagCode} shrink-0 rounded-sm`}
@@ -219,7 +219,7 @@ const countryFlagMap: Record<string, string> = {
                           <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
                             {formattedDate}
                           </td>
-                          <td class="px-4 py-3 font-semibold text-zinc-900 dark:text-zinc-100">
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
                             {winningDriverSlug ? (
                               <a
                                 href={`/seasons/${season}/drivers/${winningDriverSlug}`}
@@ -302,7 +302,7 @@ const countryFlagMap: Record<string, string> = {
                       <td class="px-4 py-3">
                         <a
                           href={`/seasons/${season}/drivers/${driver.id.split("/").pop()}`}
-                          class="font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                          class="text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
                         >
                           {driver.data.driverFirstName}{" "}
                           {driver.data.driverLastName}
@@ -379,7 +379,7 @@ const countryFlagMap: Record<string, string> = {
                       <td class="px-4 py-3">
                         <a
                           href={`/seasons/${season}/constructors/${team.id.split("/").pop()}`}
-                          class="inline-flex items-center gap-2 font-semibold text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
+                          class="inline-flex items-center gap-2 text-zinc-900 hover:text-rose-500 dark:text-zinc-100 dark:hover:text-rose-400"
                         >
                           <span
                             class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
@@ -428,14 +428,14 @@ const countryFlagMap: Record<string, string> = {
                       return (
                         <tr class="bg-white transition-colors hover:bg-zinc-50 dark:bg-zinc-900 dark:hover:bg-zinc-800/60">
                           <td class="px-4 py-3">
-                            <span class="inline-flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                            <span class="inline-flex items-center gap-2 text-zinc-900 dark:text-zinc-100">
                               <span
                                 class={`fi fi-${flagCode} shrink-0 rounded-sm`}
                               />
                               {race.data.trackCountry}
                             </span>
                           </td>
-                          <td class="px-4 py-3 font-semibold text-zinc-900 dark:text-zinc-100">
+                          <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">
                             {race.data.fastestLapDriver || "—"}
                           </td>
                           <td class="px-4 py-3 text-zinc-900 dark:text-zinc-100">


### PR DESCRIPTION
This pull request introduces several improvements and data updates to the 2026 Formula 1 season content and schema. The most significant changes are the enhancement of race result schemas to support non-numeric positions, the addition of empty result arrays to future race files, and updates to constructor data for 2026, including car models and engine suppliers.

**Schema and Data Structure Improvements:**

* Updated the `position` field in all race result schemas to accept both numbers and special status strings (e.g., "NC", "DNS", "DSQ", "DNQ", "DNF") by introducing a new `resultPositionSchema`. This change ensures the schema accurately reflects possible race result statuses. [[1]](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L2-R8) [[2]](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L133-R139) [[3]](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L146-R220) [[4]](diffhunk://#diff-0d78708eb6a4cf32e1758b9f04d0f05b751a26662664493a7c066252a0012f35L211-R233)
* Added support for additional qualifying and sprint result fields (e.g., `q1`, `q2`, `q3`, `sq1`, `sq2`, `sq3`, and `points`) in the race schema for more detailed session data.

**Race Content Updates:**

* Populated all 2026 race Markdown files with empty arrays for each result type (`raceResults`, `practice1Results`, `practice2Results`, `practice3Results`, `qualifyingResults`, `sprintResults`, `fastestLapResults`) to ensure consistent data structure and prevent errors when results are not yet available. [[1]](diffhunk://#diff-7d913224cadf599bafeda1c805bc7c7a3ccc661dd1142a2bae0a9c94e0f7cd9bR23-R29) [[2]](diffhunk://#diff-f36e0c07dfba517d11d456b5fcde678cf16fcaf96589e28fe6f326214a17c15fR23-R29) [[3]](diffhunk://#diff-e99cfa32fb4536509aa67fb177d740bed2667db22ec939acbab4b3f6abb998b7R23-R29) [[4]](diffhunk://#diff-cf63f916a51d2a4add23ccc8cd686c5387ddcd4c1cf13a27d65db6a1c9decaa8R23-R29) [[5]](diffhunk://#diff-33e0f9d307a7406b4d6d8f567921d5400fedb04c742d01ff6795e406008f0e75R23-R29) [[6]](diffhunk://#diff-a826d736753c88cb3721d78d49afb88b7d26057f4bb8020f6f39cf4dc82a3b73R23-R29) [[7]](diffhunk://#diff-a35efbe79fcbdbeee9d742d46eca097228ef483ef3da8ed7c612a833da2ec439R23-R29)

**Constructor Data Updates:**

* Updated the 2026 constructor Markdown files to reflect new car models and engine suppliers for several teams, aligning the data with the latest season information. Examples include changing Alpine's car model to "A526" and engine supplier to "Mercedes", Aston Martin's to "AMR26" and "Honda", Audi's to "R26" and "Audi", and similar updates for other teams. [[1]](diffhunk://#diff-4321d259ab8f1ab6ad0ac4f791aa9c4fdee04e540bbf651428ede3d1944d31d9L6-R6) [[2]](diffhunk://#diff-4321d259ab8f1ab6ad0ac4f791aa9c4fdee04e540bbf651428ede3d1944d31d9L22-R22) [[3]](diffhunk://#diff-70659902e83a9d3f0558be45d65314b6f1ea329efcdc4be890ccb6af506a98fdL6-R6) [[4]](diffhunk://#diff-70659902e83a9d3f0558be45d65314b6f1ea329efcdc4be890ccb6af506a98fdL22-R22) [[5]](diffhunk://#diff-552e03a2aaea445e4b0a4c1264cc66e71deb76cf8d5448d3cdb595222b25c7f5L6-R6) [[6]](diffhunk://#diff-552e03a2aaea445e4b0a4c1264cc66e71deb76cf8d5448d3cdb595222b25c7f5L22-R22) [[7]](diffhunk://#diff-f51658794439e1404328ecfb732f458d81f4ceec4efa6b892eee77a919ef6d01L6-R6) [[8]](diffhunk://#diff-f51658794439e1404328ecfb732f458d81f4ceec4efa6b892eee77a919ef6d01L16-R16) [[9]](diffhunk://#diff-c118ec6934f86e0de48e3dbb392f60f26d8f6ad1f5fde33ab6ed8cff7da0b2e9L6-R6) [[10]](diffhunk://#diff-5b34b9235fcdb4720523feeb4d07c2faa5dc3708c0885b978f14031e38661417L6-R6) [[11]](diffhunk://#diff-1a1c40e2449cde2bbd2468763b9779b18603a163c26e95b353f2ef43ea6a33c6L6-R6) [[12]](diffhunk://#diff-f5c8cec269f1fc32b016a1c5e523deb7927b055ac948c94ed98e9faa575b109aL6-R6) [[13]](diffhunk://#diff-49e0e1f4fa56f285c9dec4ebf8cef48e153c0f1b2691941259f14c97988e7e19L6-R6) [[14]](diffhunk://#diff-49e0e1f4fa56f285c9dec4ebf8cef48e153c0f1b2691941259f14c97988e7e19L22-R22) [[15]](diffhunk://#diff-4c4c1d52318eddf6791d84d4cf05d178b13c7ce3f59aab068c223a7edc9cdc61L6-R6) [[16]](diffhunk://#diff-4c4c1d52318eddf6791d84d4cf05d178b13c7ce3f59aab068c223a7edc9cdc61L22-R22) [[17]](diffhunk://#diff-6c5895758bb6cfbd9eff5ae3259fa765e20407a63593e1f53577b1b107550f7dL6-R6)

**Logic Improvements:**

* Refactored race completion logic in `RaceCard.astro` to consistently use a new `isRaceCompleted` variable, which considers both the `raceCompleted` flag and whether the race date has passed. This improves clarity and correctness in determining race status throughout the component. [[1]](diffhunk://#diff-d8a5bdfe7269801b7b2871da4679ebea219e9b66c3c78e476a69028235545e13R24) [[2]](diffhunk://#diff-d8a5bdfe7269801b7b2871da4679ebea219e9b66c3c78e476a69028235545e13L38-R39) [[3]](diffhunk://#diff-d8a5bdfe7269801b7b2871da4679ebea219e9b66c3c78e476a69028235545e13L79-R80)